### PR TITLE
Feature 3086/show invalidated selection - current verse Fix

### DIFF
--- a/build/index.js
+++ b/build/index.js
@@ -101496,7 +101496,8 @@ var InstructionsArea = function InstructionsArea(_ref) {
     );
   }
 
-  if (selections.length === 0 && dontShowTranslation) {
+  if (selections.length === 0 && dontShowTranslation && !invalidated) {
+    // if invalidated we had previous selection
     return _react2.default.createElement(
       'div',
       { className: 'instructions-area' },
@@ -101536,7 +101537,8 @@ var InstructionsArea = function InstructionsArea(_ref) {
     }
   }
 
-  if (mode === 'select') {
+  if (mode === 'select' || invalidated) {
+    // if invalidated we had previous selection
     return _react2.default.createElement(
       'div',
       { className: 'instructions-area' },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tc-ui-toolkit",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "React components used to develop tools for the desktop app translationCore",
   "main": "build/index.js",
   "scripts": {

--- a/src/VerseCheck/InstructionsArea/index.js
+++ b/src/VerseCheck/InstructionsArea/index.js
@@ -22,7 +22,7 @@ let InstructionsArea = ({
     );
   }
 
-  if (selections.length === 0 && dontShowTranslation) {
+  if (selections.length === 0 && dontShowTranslation && !invalidated) {
     return (
       <div className='instructions-area'>
         <span>{translate("no_selection")}</span><br />

--- a/src/VerseCheck/InstructionsArea/index.js
+++ b/src/VerseCheck/InstructionsArea/index.js
@@ -22,7 +22,7 @@ let InstructionsArea = ({
     );
   }
 
-  if (selections.length === 0 && dontShowTranslation && !invalidated) {
+  if (selections.length === 0 && dontShowTranslation && !invalidated) { // if invalidated we had previous selection
     return (
       <div className='instructions-area'>
         <span>{translate("no_selection")}</span><br />
@@ -52,7 +52,7 @@ let InstructionsArea = ({
     }
   }
 
-  if (mode === 'select') {
+  if (mode === 'select' || invalidated) { // if invalidated we had previous selection
     return (
       <div className='instructions-area'>
         {getSelectionString()}

--- a/src/VerseCheck/__tests__/ViewCheck.test.js
+++ b/src/VerseCheck/__tests__/ViewCheck.test.js
@@ -8,7 +8,7 @@ const base_props = require('./fixtures/project/loadedProjectShortened');
 let currentInvalidated = false;
 let currentEdited = false;
 
-describe('View component Tests', () => {
+describe('VerseCheck component:', () => {
   currentInvalidated = false;
   currentEdited = false;
 
@@ -50,7 +50,23 @@ describe('View component Tests', () => {
 
     // when
     const component = renderer.create(
-        <VerseCheck {...props} />
+      <VerseCheck {...props} />
+    );
+
+    // then
+    expect(component.toJSON()).toMatchSnapshot();
+  });
+
+  test('Integrated View test with default and invalidated', () => {
+    // given
+    const props = getBasePropertiesAndMockActions();
+    props.mode = ''; // default mode
+    currentInvalidated = true;
+    currentEdited = false;
+
+    // when
+    const component = renderer.create(
+      <VerseCheck {...props} />
     );
 
     // then

--- a/src/VerseCheck/__tests__/__snapshots__/ViewCheck.test.js.snap
+++ b/src/VerseCheck/__tests__/__snapshots__/ViewCheck.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`View component Tests Integrated View test 1`] = `
+exports[`VerseCheck component: Integrated View test 1`] = `
 <div
   className="verse-check"
 >
@@ -229,7 +229,478 @@ exports[`View component Tests Integrated View test 1`] = `
 </div>
 `;
 
-exports[`View component Tests Integrated View test with invalidated 1`] = `
+exports[`VerseCheck component: Integrated View test with default and invalidated 1`] = `
+<div
+  className="verse-check"
+>
+  <div
+    style={
+      Object {
+        "display": "flex",
+        "flexDirection": "column",
+        "height": "100%",
+        "width": "100%",
+      }
+    }
+  >
+    <div
+      className="verse-check-card"
+    >
+      <div
+        className="title-bar"
+      >
+        <span>
+          step2_check
+        </span>
+        <div
+          style={
+            Object {
+              "display": "flex",
+              "justifyContent": "flex-end",
+            }
+          }
+        >
+          <div
+            className="glyphicon glyphicon-invalidated"
+            style={
+              Object {
+                "margin": "0px 20px",
+              }
+            }
+          >
+            <svg
+              height="16"
+              style={
+                Object {
+                  "display": "inline-block",
+                  "verticalAlign": "middle",
+                }
+              }
+              viewBox="0 0 475.082 475.082"
+              width="16"
+            >
+              <path
+                d="M107.067,317.195c1.713-1.708,2.568-3.898,2.568-6.563c0-2.663-0.855-4.853-2.568-6.571    c-1.714-1.707-3.905-2.562-6.567-2.562H9.135c-2.666,0-4.853,0.855-6.567,2.562C0.859,305.772,0,307.962,0,310.632    c0,2.665,0.855,4.855,2.568,6.563c1.714,1.711,3.905,2.566,6.567,2.566H100.5C103.166,319.766,105.353,318.91,107.067,317.195z"
+                style={
+                  Object {
+                    "fill": "#ffffff",
+                  }
+                }
+              />
+              <path
+                d="M310.629,109.634c2.669,0,4.859-0.855,6.563-2.568c1.718-1.711,2.574-3.901,2.574-6.567V9.138    c0-2.659-0.856-4.85-2.574-6.565c-1.704-1.711-3.895-2.57-6.563-2.57c-2.662,0-4.853,0.859-6.563,2.57    c-1.711,1.713-2.566,3.903-2.566,6.565v91.361c0,2.666,0.855,4.856,2.566,6.567C305.784,108.779,307.974,109.634,310.629,109.634z    "
+                style={
+                  Object {
+                    "fill": "#ffffff",
+                  }
+                }
+              />
+              <path
+                d="M118.771,347.184c-2.478,0-4.664,0.855-6.567,2.563l-73.089,73.087c-1.713,1.902-2.568,4.093-2.568,6.567    c0,2.474,0.855,4.664,2.568,6.566c2.096,1.708,4.283,2.57,6.567,2.57c2.475,0,4.665-0.862,6.567-2.57l73.089-73.087    c1.714-1.902,2.568-4.093,2.568-6.57c0-2.471-0.854-4.661-2.568-6.563C123.436,348.039,121.245,347.184,118.771,347.184z"
+                style={
+                  Object {
+                    "fill": "#ffffff",
+                  }
+                }
+              />
+              <path
+                d="M356.315,127.905c2.283,0,4.473-0.855,6.571-2.565l73.087-73.089c1.707-1.903,2.562-4.093,2.562-6.567    c0-2.475-0.855-4.665-2.562-6.567c-1.91-1.709-4.093-2.568-6.571-2.568c-2.471,0-4.66,0.859-6.563,2.568l-73.087,73.089    c-1.708,1.903-2.57,4.093-2.57,6.567c0,2.474,0.862,4.661,2.57,6.567C351.846,127.05,354.037,127.905,356.315,127.905z"
+                style={
+                  Object {
+                    "fill": "#ffffff",
+                  }
+                }
+              />
+              <path
+                d="M350.607,193.005c-4-3.999-9.328-7.994-15.988-11.991l-5.14,68.238l78.23,78.508c5.328,5.328,7.987,11.807,7.987,19.417    c0,7.423-2.662,13.802-7.987,19.13l-41.977,41.686c-5.146,5.146-11.608,7.666-19.417,7.566c-7.81-0.1-14.271-2.707-19.411-7.854    l-77.946-78.225l-68.234,5.144c3.999,6.656,7.993,11.988,11.991,15.985l95.362,95.643c15.803,16.18,35.207,24.27,58.238,24.27    c22.846,0,42.154-7.898,57.957-23.695l41.977-41.685c16.173-15.8,24.27-35.115,24.27-57.958c0-22.46-7.994-41.877-23.982-58.248    L350.607,193.005z"
+                style={
+                  Object {
+                    "fill": "#ffffff",
+                  }
+                }
+              />
+              <path
+                d="M472.518,157.889c-1.711-1.709-3.901-2.565-6.563-2.565h-91.365c-2.662,0-4.853,0.855-6.563,2.565    c-1.715,1.713-2.57,3.903-2.57,6.567c0,2.666,0.855,4.856,2.57,6.567c1.711,1.712,3.901,2.568,6.563,2.568h91.365    c2.662,0,4.853-0.856,6.563-2.568c1.708-1.711,2.563-3.901,2.563-6.567C475.082,161.792,474.226,159.602,472.518,157.889z"
+                style={
+                  Object {
+                    "fill": "#ffffff",
+                  }
+                }
+              />
+              <path
+                d="M109.348,67.099c5.523-5.14,11.991-7.705,19.417-7.705c7.611,0,14.084,2.663,19.414,7.993l77.943,78.227l68.234-5.142    c-4-6.661-7.99-11.991-11.991-15.987l-95.358-95.643c-15.798-16.178-35.212-24.27-58.242-24.27c-22.841,0-42.16,7.902-57.958,23.7    L28.837,69.955C12.659,85.756,4.57,105.073,4.57,127.912c0,22.463,7.996,41.877,23.982,58.245l95.93,95.93    c3.995,4.001,9.325,7.995,15.986,11.991l5.139-68.521L67.377,147.33c-5.327-5.33-7.992-11.801-7.992-19.417    c0-7.421,2.662-13.796,7.992-19.126L109.348,67.099z"
+                style={
+                  Object {
+                    "fill": "#ffffff",
+                  }
+                }
+              />
+              <path
+                d="M164.454,365.451c-2.667,0-4.854,0.855-6.567,2.563c-1.711,1.711-2.568,3.901-2.568,6.57v91.358    c0,2.669,0.854,4.853,2.568,6.57c1.713,1.707,3.9,2.566,6.567,2.566c2.666,0,4.853-0.859,6.567-2.566    c1.713-1.718,2.568-3.901,2.568-6.57v-91.358c0-2.662-0.855-4.853-2.568-6.57C169.306,366.307,167.116,365.451,164.454,365.451z"
+                style={
+                  Object {
+                    "fill": "#ffffff",
+                  }
+                }
+              />
+            </svg>
+          </div>
+          <span
+            className="glyphicon glyphicon-ok"
+            style={
+              Object {
+                "color": "var(--reverse-color)",
+                "margin": "0px 20px",
+                "opacity": 0.2,
+              }
+            }
+            title="icons.no_selections_found"
+          />
+          <span
+            className="glyphicon glyphicon-pencil"
+            style={
+              Object {
+                "color": "var(--reverse-color)",
+                "margin": "0px 20px",
+                "opacity": 0.2,
+              }
+            }
+            title="icons.no_verse_edits_found"
+          />
+          <span
+            className="glyphicon glyphicon-comment"
+            style={
+              Object {
+                "color": "var(--reverse-color)",
+                "margin": "0px 20px",
+                "opacity": 0.2,
+              }
+            }
+            title="icons.no_comments_found"
+          />
+          <span
+            className="glyphicon glyphicon-bookmark"
+            style={
+              Object {
+                "color": "var(--reverse-color)",
+                "margin": "0px 20px",
+                "opacity": 0.2,
+              }
+            }
+            title="icons.not_bookmarked"
+          />
+        </div>
+      </div>
+      <div
+        className="check-area"
+      >
+        <div
+          style={
+            Object {
+              "WebkitUserSelect": "none",
+              "display": "flex",
+              "flex": 1,
+              "flexDirection": "column",
+            }
+          }
+        >
+          <div
+            className="verse-title"
+          >
+            <div
+              className="pane"
+              style={
+                Object {
+                  "display": "flex",
+                  "flexDirection": "column",
+                }
+              }
+            >
+              <span
+                className="verse-title-title"
+              >
+                Fwe
+              </span>
+              <span
+                className="verse-title-subtitle"
+              >
+                Titus
+                 
+                2:5
+              </span>
+            </div>
+            <div
+              onClick={[Function]}
+            >
+              <span
+                className="glyphicon glyphicon-fullscreen"
+                style={
+                  Object {
+                    "cursor": "pointer",
+                  }
+                }
+                title="click_show_expanded"
+              />
+            </div>
+          </div>
+          <div
+            className="ltr-content"
+          >
+            <div
+              style={
+                Object {
+                  "color": "var(--text-color-light)",
+                  "userSelect": "none",
+                }
+              }
+            >
+              <span>
+                Kono ewe, oambe ziyenderera ne ntaero zisepahara. 
+              </span>
+            </div>
+          </div>
+        </div>
+        <div
+          style={
+            Object {
+              "borderLeft": "1px solid var(--border-color)",
+              "display": "flex",
+              "flex": 1,
+              "justifyContent": "center",
+              "overflowY": "auto",
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "WebkitUserSelect": "none",
+                "alignItems": "center",
+                "display": "flex",
+                "height": "100%",
+                "justifyContent": "center",
+              }
+            }
+          >
+            <div
+              className="instructions-area"
+            >
+              <div>
+                <span>
+                  selection_invalidated
+                  <strong
+                    data-class="selection-tooltip"
+                    data-delay-hide="100"
+                    data-effect="float"
+                    data-place="top"
+                    data-tip="invalidated_tooltip"
+                    data-type="dark"
+                    style={
+                      Object {
+                        "font-size": "0.8em",
+                        "vertical-align": "super",
+                      }
+                    }
+                  >
+                    1
+                  </strong>
+                </span>
+                <div
+                  className="__react_component_tooltip place-top type-dark "
+                  data-id="tooltip"
+                  id={undefined}
+                />
+              </div>
+              <span>
+                please_select
+              </span>
+              <br />
+              <span>
+                <strong
+                  style={
+                    Object {
+                      "color": "var(--accent-color)",
+                    }
+                  }
+                >
+                  ""
+                </strong>
+              </span>
+              <br />
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="actions-area"
+      >
+        <label
+          className="MuiFormControlLabel-root-39"
+          style={
+            Object {
+              "paddingLeft": 10,
+            }
+          }
+        >
+          <span
+            className="MuiSwitch-root-42"
+          >
+            <span
+              className="MuiButtonBase-root-61 MuiIconButton-root-55 MuiSwitchBase-root-51 MuiSwitch-switchBase-45 MuiSwitch-colorPrimary-47 Bookmark-colorPrimary-38"
+              onBlur={[Function]}
+              onFocus={[Function]}
+              onKeyDown={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseLeave={[Function]}
+              onMouseUp={[Function]}
+              onTouchEnd={[Function]}
+              onTouchMove={[Function]}
+              onTouchStart={[Function]}
+              role={undefined}
+              tabIndex={null}
+            >
+              <span
+                className="MuiIconButton-label-60"
+              >
+                <span
+                  className="MuiSwitch-icon-43"
+                />
+                <input
+                  checked={false}
+                  className="MuiSwitchBase-input-54"
+                  disabled={false}
+                  id={undefined}
+                  name={undefined}
+                  onChange={[Function]}
+                  tabIndex={undefined}
+                  type="checkbox"
+                  value="bookmark"
+                />
+              </span>
+              <span
+                className="MuiTouchRipple-root-64"
+              />
+            </span>
+            <span
+              className="MuiSwitch-bar-50"
+            />
+          </span>
+          <span
+            className="MuiTypography-root-71 MuiTypography-body1-80 MuiFormControlLabel-label-41 Bookmark-label-37"
+          >
+            bookmark
+          </span>
+        </label>
+        <div
+          style={
+            Object {
+              "display": "flex",
+              "marginLeft": "auto",
+            }
+          }
+        >
+          <button
+            className="btn-second"
+            onClick={[Function]}
+            style={
+              Object {
+                "marginRigth": "5px",
+                "width": "140px",
+              }
+            }
+          >
+            <span
+              className="glyphicon glyphicon-ok"
+              style={
+                Object {
+                  "marginRight": "10px",
+                }
+              }
+            />
+            select
+          </button>
+          <button
+            className="btn-second"
+            onClick={[Function]}
+            style={
+              Object {
+                "marginRigth": "5px",
+                "width": "140px",
+              }
+            }
+          >
+            <span
+              className="glyphicon glyphicon-pencil"
+              style={
+                Object {
+                  "marginRight": "10px",
+                }
+              }
+            />
+            edit_verse
+          </button>
+          <button
+            className="btn-second"
+            onClick={[Function]}
+            style={
+              Object {
+                "width": "140px",
+              }
+            }
+          >
+            <span
+              className="glyphicon glyphicon-comment"
+              style={
+                Object {
+                  "marginRight": "10px",
+                }
+              }
+            />
+            comment
+          </button>
+        </div>
+      </div>
+    </div>
+    <div
+      className="save-area"
+    >
+      <button
+        className="btn-second"
+        onClick={[Function]}
+      >
+        <span
+          className="glyphicon glyphicon-share-alt"
+          style={
+            Object {
+              "marginRight": "10px",
+              "transform": "scaleX(-1)",
+            }
+          }
+        />
+        save_previous
+      </button>
+      <button
+        className="btn-prime"
+        onClick={[Function]}
+      >
+        save_continue
+        <span
+          className="glyphicon glyphicon-share-alt"
+          style={
+            Object {
+              "marginLeft": "10px",
+            }
+          }
+        />
+      </button>
+    </div>
+  </div>
+  <div />
+</div>
+`;
+
+exports[`VerseCheck component: Integrated View test with invalidated 1`] = `
 <div
   className="verse-check"
 >
@@ -569,7 +1040,7 @@ exports[`View component Tests Integrated View test with invalidated 1`] = `
 </div>
 `;
 
-exports[`View component Tests Integrated View test with verseEdit 1`] = `
+exports[`VerseCheck component: Integrated View test with verseEdit 1`] = `
 <div
   className="verse-check"
 >


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- fixes issue in tW that if the initial verse was invalidated, it would start up with select verse

#### Please include detailed Test instructions for your pull request:
- Local testing setup: 
  `git fetch`
  `git checkout develop`
  `git pull`
  `npm run update-apps`
  `npm i`
  `rm -rf node_modules/tc-ui-toolkit`
  `npm i translationCoreApps/tc-ui-toolkit#feature-mcleanb-3086/ShowInvalidatedSelection.5`
  `npm start`

- Test steps:
  - open tw tool.  
  - Under blameless, for vs 1:6 select "without blame" 
  - edit 1:6 to remove space to make selection "withoutblame".  
  - verify invalidated icon on group menu and on verse check bar and invalidated message on instructions.  
  - Exit tw tool
  - open tw tool again and verify invalidated icon on group menu and on verse check bar and invalidated message on instructions.  

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/translationcoreapps/tc-ui-toolkit/40)
<!-- Reviewable:end -->
