### PR TITLE
Now removing \pi USFM marker in the the scripture pane

### DIFF
--- a/build/index.js
+++ b/build/index.js
@@ -69788,7 +69788,8 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 var verseString = exports.verseString = function verseString(verseText, selections, translate) {
   verseText = (0, _usfmHelpers.removeMarker)(verseText);
   verseText = verseText.replace(/\s+/g, ' ');
-
+  // remove \pi marker
+  verseText = verseText.replace(/\\pi/g, '');
   // remove \s5 and \p markers from string
   var regString = '\\\\\\w[0-9]*';
   var regex = new RegExp(regString, 'g');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tc-ui-toolkit",
-  "version": "0.9.15",
+  "version": "0.9.16",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tc-ui-toolkit",
-  "version": "0.9.15",
+  "version": "0.9.16",
   "description": "React components used to develop tools for the desktop app translationCore",
   "main": "build/index.js",
   "scripts": {

--- a/src/ScripturePane/helpers/verseHelpers.js
+++ b/src/ScripturePane/helpers/verseHelpers.js
@@ -11,7 +11,8 @@ import { isWord, isNestedMilestone, punctuationWordSpacing, textIsEmptyInVerseOb
 export const verseString = (verseText, selections, translate) => {
   verseText = removeMarker(verseText);
   verseText = verseText.replace(/\s+/g, ' ');
-
+  // remove \pi marker
+  verseText = verseText.replace(/\\pi/g, '');
   // remove \s5 and \p markers from string
   const regString = '\\\\\\w[0-9]*';
   const regex = new RegExp(regString, 'g');

--- a/tc-ui-toolkit-test/src/assets/scripturePaneProps.js
+++ b/tc-ui-toolkit-test/src/assets/scripturePaneProps.js
@@ -14041,7 +14041,7 @@ export const bibles = {
   targetLanguage: {
     targetBible: {
       1: {
-        "1": "\\f + \\ft The best ancient copies omit v. 21, \\fqa But this kind of demon does not go out except with prayer and fasting \\fqa* . \\f*\n\n\\s5\n\\p",
+        "1": "\\f + \\ft The best ancient copies omit v. 21, \\fqa But this kind of demon does not go out except with prayer and fasting \\fqa* . \\f*\n\n\\s5\n\\p \\pi hello",
         "2": "तैस हमेंशरी ज़िन्दगरे उमीदी पुड़, ज़ैसेरो वेइदो परमेशरे ज़ै झूठ न ज़ोए पेहिलो देंतेरो कीयोरोए|",
         "3": "पण ठीक वक्ते पुड़ अपनो वचन तैस प्रचारे सैहीं बांदो केरो, ज़ै इशे मुक्ति देंने बाले परमेशरेरे हुकमेरे मुताबिक मीं सोंफोरोए|",
         "4": "तीतुसेरे नोंवे ज़ैन विशवासे सैहीं मेरू सच़ू मठ्ठूए: बाजी परमेशर ते इशे मुक्ति देंने बाले प्रभु यीशु मसीहेरे तरफाँ अनुग्रह ते शान्ति भोती राए|\n\\s क्रेते मां तीतुसेरू कम्म",


### PR DESCRIPTION
- load the tc-ui-toolkit-test and it should only render hello in the target language pane

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/translationcoreapps/tc-ui-toolkit/48)
<!-- Reviewable:end -->
