### PR TITLE
Fixes menu scroll

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tc-ui-toolkit",
-  "version": "0.10.12",
+  "version": "0.10.13",
   "description": "React components used to develop tools for the desktop app translationCore",
   "main": "dist/bundle.js",
   "scripts": {

--- a/src/GroupMenu/Group/index.js
+++ b/src/GroupMenu/Group/index.js
@@ -28,13 +28,9 @@ class Group extends React.Component {
   }
 
   componentDidMount() {
-    if (this.props.active)
+    if (this.props.active) {
       this.scrollToCurrentCheck();
-  }
-
-  componentDidUpdate() {
-    if (this.props.active)
-    this.scrollToCurrentCheck();
+    }
   }
 
   render() {
@@ -57,18 +53,19 @@ class Group extends React.Component {
     } = this.props;
     let groupMenuItemHeadingClassName = active ? 'menu-item-heading-current' : 'menu-item-heading-normal';
 
-    let glyphAction = active ? groupMenuExpandSubMenu : openGroup;
     let expandedGlyph = (
-      <Glyphicon glyph="chevron-down" style={{float: 'right', marginTop: '3px'}} onClick={() => glyphAction(false)} />
+      <Glyphicon glyph="chevron-down" style={{float: 'right', marginTop: '3px'}}/>
     );
     let collapsedGlyph = (
-      <Glyphicon glyph="chevron-right" style={{float: 'right', marginTop: '3px'}} onClick={() => glyphAction(true)} />
+      <Glyphicon glyph="chevron-right" style={{float: 'right', marginTop: '3px'}}/>
     );
     return (
         <div className="group">
-          <div ref={this.currentGroupRef} className={groupMenuItemHeadingClassName}>
+          <div ref={this.currentGroupRef}
+               onClick={openGroup}
+               className={groupMenuItemHeadingClassName}>
             {active && isSubMenuExpanded ? expandedGlyph : collapsedGlyph}
-            <div onClick={openGroup} style={{display: 'flex'}}>
+            <div style={{display: 'flex'}}>
               <div style={{position: 'relative', justifyContent: 'center', height: 20, width: 20, display: 'flex', marginRight: '10px', float: 'left'}}>
                 <div style={{height: 20, width: 20, border: 'white solid 3px', borderRadius: '50%'}} />
                 <CircularProgress

--- a/src/GroupMenu/Group/index.js
+++ b/src/GroupMenu/Group/index.js
@@ -33,11 +33,18 @@ class Group extends React.Component {
     }
   }
 
+  componentDidUpdate(prevProps) {
+    const {contextId: oldContext} = prevProps;
+    const {active, contextId: newContext} = this.props;
+    if(active && newContext.groupId !== oldContext.groupId) {
+      this.scrollToCurrentCheck();
+    }
+  }
+
   render() {
     const {
       changeCurrentContextId,
       active,
-      groupMenuExpandSubMenu,
       openGroup,
       isSubMenuExpanded,
       progress,

--- a/src/GroupMenu/GroupMenu.styles.css
+++ b/src/GroupMenu/GroupMenu.styles.css
@@ -45,11 +45,11 @@
 .selection-tooltip {
   max-width: 200px;
   opacity: 1!important;
-  background-color: var(--background-color-light);
+  background-color: var(--background-color-light)!important;
   box-shadow: 0px 1px 5px 0px rgba(50, 50, 50, 0.54);
 }
 .selection-tooltip:after {
-  border-bottom-color: var(--background-color-light);
+  border-bottom-color: var(--background-color-light)!important;
 }
 
 .group-menu-status-tooltip {


### PR DESCRIPTION
Related to https://github.com/unfoldingWord-dev/translationCore/issues/5140.
Also related to https://github.com/unfoldingWord-dev/translationCore/issues/5097 since the fix was super tiny.

- This updates the group menu to only scroll to the selected context when the tool starts and when a group is opened.
- Fixes the clickable area of a group so that groups can be opened by clicking anywhere on the header instead of just on the text.
- Corrects the background color of popups in the groups menu.

Here's an illustration of the improvement
![menu-scroll-fix](https://user-images.githubusercontent.com/166412/47247811-bd69b780-d3ba-11e8-886c-1db373f551ad.gif)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/translationcoreapps/tc-ui-toolkit/75)
<!-- Reviewable:end -->
