### PR TITLE
Fixed missing text warning not displayed in scripture pane

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tc-ui-toolkit",
-  "version": "0.10.14",
+  "version": "0.11.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -11281,7 +11281,7 @@
           "resolved": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz",
           "integrity": "sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=",
           "requires": {
-            "loose-envify": "1.3.1"
+            "loose-envify": "^1.0.0"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tc-ui-toolkit",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "description": "React components used to develop tools for the desktop app translationCore",
   "main": "dist/bundle.js",
   "scripts": {

--- a/src/ScripturePane/helpers/bibleHelpers.js
+++ b/src/ScripturePane/helpers/bibleHelpers.js
@@ -37,7 +37,7 @@ export const getCurrentVersesWithHighlightedWords = (bibles, selections, context
             const { reference: { verse } } = contextId;
             const verseData = chapterData[verse];
 
-            if (verseData && typeof verseData === 'string') { // if the verse content is string.
+           if (verseData.length === 0 && typeof verseData === 'string') { // if the verse content is string.
               parsedBible[languageId][bibleId]['bibleData'][chapterNumber][verse] = verseString(verseData, selections, translate);
             } else if (verseData) { // then the verse content is an array/verse objects.
               parsedBible[languageId][bibleId]['bibleData'][chapterNumber][verse] = verseArray(verseData, bibleId, contextId, getLexiconData, showPopover, translate);
@@ -98,7 +98,8 @@ export const getBiblesWithHighlightedWords = async (bibles, selections, contextI
             for (let l = 0, lLength = Object.keys(chapterData).length; l < lLength; l++) {
               const verseNumber = Object.keys(chapterData)[l];
               const verseData = chapterData[verseNumber];
-              if (verseData && typeof verseData === 'string') { // if the verse content is string.
+
+              if (verseData.length === 0 && typeof verseData === 'string') { // if the verse content is string.
                 parsedBible[languageId][bibleId]['bibleData'][chapterNumber][verseNumber] = verseString(verseData, selections, translate);
               } else if (verseData) { // then the verse content is an array/verse objects.
                 parsedBible[languageId][bibleId]['bibleData'][chapterNumber][verseNumber] = verseArray(verseData, bibleId, contextId, getLexiconData, showPopover, translate);

--- a/src/ScripturePane/helpers/bibleHelpers.js
+++ b/src/ScripturePane/helpers/bibleHelpers.js
@@ -37,7 +37,7 @@ export const getCurrentVersesWithHighlightedWords = (bibles, selections, context
             const { reference: { verse } } = contextId;
             const verseData = chapterData[verse];
 
-           if (verseData.length === 0 && typeof verseData === 'string') { // if the verse content is string.
+           if (typeof verseData === 'string') { // if the verse content is string.
               parsedBible[languageId][bibleId]['bibleData'][chapterNumber][verse] = verseString(verseData, selections, translate);
             } else if (verseData) { // then the verse content is an array/verse objects.
               parsedBible[languageId][bibleId]['bibleData'][chapterNumber][verse] = verseArray(verseData, bibleId, contextId, getLexiconData, showPopover, translate);
@@ -99,7 +99,7 @@ export const getBiblesWithHighlightedWords = async (bibles, selections, contextI
               const verseNumber = Object.keys(chapterData)[l];
               const verseData = chapterData[verseNumber];
 
-              if (verseData.length === 0 && typeof verseData === 'string') { // if the verse content is string.
+              if (typeof verseData === 'string') { // if the verse content is string.
                 parsedBible[languageId][bibleId]['bibleData'][chapterNumber][verseNumber] = verseString(verseData, selections, translate);
               } else if (verseData) { // then the verse content is an array/verse objects.
                 parsedBible[languageId][bibleId]['bibleData'][chapterNumber][verseNumber] = verseArray(verseData, bibleId, contextId, getLexiconData, showPopover, translate);

--- a/tc-ui-toolkit-test/src/assets/scripturePaneProps.js
+++ b/tc-ui-toolkit-test/src/assets/scripturePaneProps.js
@@ -14519,8 +14519,8 @@ export const bibles = {
   targetLanguage: {
     targetBible: {
       1: {
-        "1": "\\f + \\ft The best ancient copies omit v. 21, \\fqa But this kind of demon does not go out except with prayer and fasting \\fqa* . \\f*\n\n\\s5\n\\p \\pi hello",
-        "2": "तैस हमेंशरी ज़िन्दगरे उमीदी पुड़, ज़ैसेरो वेइदो परमेशरे ज़ै झूठ न ज़ोए पेहिलो देंतेरो कीयोरोए|",
+        "1": "",
+        "2": "\\f + \\ft The best ancient copies omit v. 21, \\fqa But this kind of demon does not go out except with prayer and fasting \\fqa* . \\f*\n\n\\s5\n\\p \\pi hello",
         "3": "पण ठीक वक्ते पुड़ अपनो वचन तैस प्रचारे सैहीं बांदो केरो, ज़ै इशे मुक्ति देंने बाले परमेशरेरे हुकमेरे मुताबिक मीं सोंफोरोए|",
         "4": "तीतुसेरे नोंवे ज़ैन विशवासे सैहीं मेरू सच़ू मठ्ठूए: बाजी परमेशर ते इशे मुक्ति देंने बाले प्रभु यीशु मसीहेरे तरफाँ अनुग्रह ते शान्ति भोती राए|\n\\s क्रेते मां तीतुसेरू कम्म",
         "5": "मीं तू ऐलहेरे लेई करेते मां शारोरो थू, कि तू बाकी रेवरी गल्लन सुधारस, ते मेरे हुकमेरे मुताबिक नगरे नगरे मां बुज़ुरग च़ुनस|",


### PR DESCRIPTION
- On tC `release-v1.0.2` run `npm i translationCoreApps/tc-ui-toolkit#bugfix-mannycolon-5266 `
- Open [es-419_reg_luk_book.zip](https://github.com/unfoldingWord-dev/translationCore/files/2490175/es-419_reg_luk_book.zip) w/ tW tool
- Go to Luke 1:2 on `word of God, words of God, word of Yahweh, word of the Lord, word of truth, scripture, scriptures` check
- The following warning should show
![image](https://user-images.githubusercontent.com/8171759/47131182-fa229b00-d262-11e8-96e4-965f302d1f82.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/translationcoreapps/tc-ui-toolkit/86)
<!-- Reviewable:end -->
