### PR TITLE
Feature 5863/fix WordLexiconDetails when word has a ZERO_WIDTH_JOINER

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tc-ui-toolkit",
-  "version": "0.13.17",
+  "version": "0.13.19",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tc-ui-toolkit",
-  "version": "0.13.17",
+  "version": "0.13.19",
   "description": "React components used to develop tools for the desktop app translationCore",
   "main": "dist/bundle.js",
   "display": "library",

--- a/src/ScripturePane/helpers/lexiconHelpers.js
+++ b/src/ScripturePane/helpers/lexiconHelpers.js
@@ -1,6 +1,7 @@
 import {MorphUtils} from "word-aligner";
 
 const ZERO_WIDTH_SPACE = '\u200B';
+const ZERO_WIDTH_JOINER = '\u2060';
 
 /**
  * splits a word by zero width spaces
@@ -9,7 +10,12 @@ const ZERO_WIDTH_SPACE = '\u200B';
  */
 export const getWordParts = (word) => {
   if (word) {
-    const wordParts = word.split(ZERO_WIDTH_SPACE);
+    let wordParts = [word];
+    if (word.includes(ZERO_WIDTH_JOINER)) {
+      wordParts = word.split(ZERO_WIDTH_JOINER);
+    } else if (word.includes(ZERO_WIDTH_SPACE)) {
+      wordParts = word.split(ZERO_WIDTH_SPACE);
+    }
     return wordParts;
   }
   return [];

--- a/src/WordLexiconDetails/WordLexiconDetails.test.js
+++ b/src/WordLexiconDetails/WordLexiconDetails.test.js
@@ -407,6 +407,25 @@ describe('WordLexiconDetails', () => {
             "morph": "morph_missing",
             "itemNum": 1
           }
+        ]},
+      {"text":"הַ⁠שֹּׁפְטִ֔ים","lemma":"שָׁפַט","strong":"d:H8199","morph": "He,Td:Vqrmpa", // Ruth 1:1 - zero space joiner
+        results: [
+          {
+            "word": "שֹּׁפְטִ֔ים",
+            "strongNum": 8199,
+            "strong": "H8199",
+            "lemma": "שָׁפַט",
+            "morph": "verb, qal, participle_active, masculine, plural, absolute",
+            "lexicon": "uhl-8199",
+            "itemNum": 1
+          },
+          {
+            "word": "הַ",
+            "strong": "d",
+            "morph": "particle, definite_article",
+            "itemNum": 0
+          },
+
         ]}
     ];
 


### PR DESCRIPTION
#### Changes
- lexiconHelpers - added support for ZERO_WIDTH_JOINER in splitting word.

#### Testing
- should pass on Travis

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/translationcoreapps/tc-ui-toolkit/195)
<!-- Reviewable:end -->
