### PR TITLE
Added info icon to "no selection needed" checkbox & made expanded scripture pane and verse editor dialogs draggable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8811,6 +8811,15 @@
         "scheduler": "^0.13.6"
       }
     },
+    "react-draggable": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/react-draggable/-/react-draggable-3.3.0.tgz",
+      "integrity": "sha512-U7/jD0tAW4T0S7DCPK0kkKLyL0z61sC/eqU+NUfDjnq+JtBKaYKDHpsK2wazctiA4alEzCXUnzkREoxppOySVw==",
+      "requires": {
+        "classnames": "^2.2.5",
+        "prop-types": "^15.6.0"
+      }
+    },
     "react-event-listener": {
       "version": "0.6.6",
       "resolved": "https://registry.npmjs.org/react-event-listener/-/react-event-listener-0.6.6.tgz",

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "prop-types": "^15.6.1",
     "react-bootstrap": "^0.32.1",
     "react-container-dimensions": "^1.3.3",
+    "react-draggable": "^3.3.0",
     "react-remarkable": "^1.1.3",
     "react-tooltip": "^3.5.1",
     "string-punctuation-tokenizer": "^0.9.4",

--- a/src/ScripturePane/ExpandedScripturePaneModal/ChapterView/index.js
+++ b/src/ScripturePane/ExpandedScripturePaneModal/ChapterView/index.js
@@ -11,16 +11,6 @@ import VerseRow from './VerseRow';
 import VerseEditorDialog from '../../../VerseEditor';
 
 class ChapterView extends Component {
-  constructor(props) {
-    super(props);
-    this.handleEditTargetVerse = this.handleEditTargetVerse.bind(this);
-    this.handleEditorCancel = this.handleEditorCancel.bind(this);
-    this.handleEditorSubmit = this.handleEditorSubmit.bind(this);
-    this.state = {
-      editVerse: null
-    };
-  }
-
   componentDidMount() {
     let { chapter, verse } = this.props.contextId.reference;
     let verseReference = ChapterView.makeRefKey(chapter, verse);
@@ -39,45 +29,6 @@ class ChapterView extends Component {
     return `c${chapter.toString()}v${verse.toString()}`;
   }
 
-   /**
-   * Handles events to edit the target verse
-   * @param bibleId
-   * @param chapter
-   * @param verse
-   * @param verseText
-   */
-  handleEditTargetVerse(bibleId, chapter, verse, verseText) {
-    this.setState({
-      editVerse: {
-        bibleId,
-        chapter,
-        verse,
-        verseText
-      }
-    });
-  }
-
-  handleEditorSubmit(originalVerse, newVerse, reasons) {
-    const { editTargetVerse } = this.props;
-    const {editVerse} = this.state;
-    if(editVerse === null) return;
-    const {chapter, verse} = editVerse;
-    if(typeof editTargetVerse === 'function') {
-      editTargetVerse(chapter, verse, originalVerse, newVerse, reasons);
-    } else {
-      console.warn('Unable to edit verse. Callback is not a function.');
-    }
-    this.setState({
-      editVerse: null
-    });
-  }
-
-  handleEditorCancel() {
-    this.setState({
-      editVerse: null
-    });
-  }
-
   componentWillUnmount() {
     this.verseRefs = {};
   }
@@ -92,6 +43,9 @@ class ChapterView extends Component {
       selections,
       getLexiconData,
       showPopover,
+      handleEditTargetVerse,
+      handleEditorSubmit,
+      handleEditorCancel,
     } = this.props;
 
     const { chapter, verse } = contextId.reference;
@@ -117,13 +71,13 @@ class ChapterView extends Component {
             getLexiconData={getLexiconData}
             currentVerseNumber={verseNumber}
             currentPaneSettings={currentPaneSettings}
-            onEditTargetVerse={this.handleEditTargetVerse}
+            onEditTargetVerse={handleEditTargetVerse}
             ref={node => this.verseRefs[refKey] = node} />
         );
       }
     }
 
-    const { editVerse } = this.state;
+    const { editVerse } = this.props;
     const openEditor = editVerse !== null;
     let verseTitle = '';
     let verseText = '';
@@ -143,9 +97,9 @@ class ChapterView extends Component {
           {verseRows}
         </div>
         <VerseEditorDialog translate={translate}
-                           onSubmit={this.handleEditorSubmit}
+                           onSubmit={handleEditorSubmit}
                            open={openEditor}
-                           onCancel={this.handleEditorCancel}
+                           onCancel={handleEditorCancel}
                            verseText={verseText}
                            verseTitle={verseTitle}/>
       </div>
@@ -163,6 +117,10 @@ ChapterView.propTypes = {
   selections: PropTypes.array.isRequired,
   getLexiconData: PropTypes.func.isRequired,
   showPopover: PropTypes.func.isRequired,
+  editVerse: PropTypes.object,
+  handleEditTargetVerse: PropTypes.func.isRequired,
+  handleEditorSubmit: PropTypes.func.isRequired,
+  handleEditorCancel: PropTypes.func.isRequired,
 };
 
 export default ChapterView;

--- a/src/VerseCheck/ActionsArea/ActionsArea.styles.css
+++ b/src/VerseCheck/ActionsArea/ActionsArea.styles.css
@@ -9,3 +9,8 @@
   display: flex;
   justify-content: space-between;
 }
+
+.flex-row {
+  display: flex;
+  align-items: center;
+}

--- a/src/VerseCheck/ActionsArea/index.js
+++ b/src/VerseCheck/ActionsArea/index.js
@@ -4,6 +4,8 @@ import isEqual from 'deep-equal';
 import Checkbox from '@material-ui/core/Checkbox';
 import { withStyles } from '@material-ui/core/styles';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
+import InfoIcon from '@material-ui/icons/Info';
+
 import ReactTooltip from 'react-tooltip';
 // components
 import Bookmark from '../../Bookmark';
@@ -27,6 +29,14 @@ const styles = {
     },
   },
   checked: {},
+  icon: {
+    color: 'var(--accent-color-dark)',
+    verticalAlign: 'middle',
+    margin: '5px',
+    width: 30,
+    height: 30,
+    cursor: 'pointer'
+  },
 };
 
 
@@ -128,15 +138,7 @@ let ActionsArea = ({
   );
   const confirmSelectionArea = (
     <div className='selection-actions-area'>
-      <div
-        data-tip={translate('nothing_to_select_description')}
-        data-place="top"
-        data-effect="float"
-        data-type="dark"
-        data-class="selection-tooltip"
-        data-delay-hide="100"
-        style={{ verticalAlign: 'super', fontSize: '0.8em' }}
-      >
+      <div className='flex-row'>
         <FormControlLabel
           value="end"
           control={
@@ -158,7 +160,18 @@ let ActionsArea = ({
             label: classes.label
           }}
         />
-        <ReactTooltip/>
+        <div
+          data-tip={translate('nothing_to_select_description')}
+          data-place="top"
+          data-effect="float"
+          data-type="dark"
+          data-class="selection-tooltip"
+          data-delay-hide="100"
+          style={{ verticalAlign: 'super', fontSize: '0.8em' }}
+        >
+          <InfoIcon classes={{ root: classes.icon }} />
+          <ReactTooltip/>
+        </div>
       </div>
       <div>
         <button

--- a/src/VerseCheck/__tests__/__snapshots__/ViewCheck.test.js.snap
+++ b/src/VerseCheck/__tests__/__snapshots__/ViewCheck.test.js.snap
@@ -590,24 +590,13 @@ exports[`VerseCheck component: Integrated View test 1`] = `
         className="selection-actions-area"
       >
         <div
-          data-class="selection-tooltip"
-          data-delay-hide="100"
-          data-effect="float"
-          data-place="top"
-          data-tip="nothing_to_select_description"
-          data-type="dark"
-          style={
-            Object {
-              "fontSize": "0.8em",
-              "verticalAlign": "super",
-            }
-          }
+          className="flex-row"
         >
           <label
-            className="MuiFormControlLabel-root-5 ActionsArea-formControl-1"
+            className="MuiFormControlLabel-root-6 ActionsArea-formControl-1"
           >
             <span
-              className="MuiButtonBase-root-27 MuiIconButton-root-21 MuiPrivateSwitchBase-root-17 MuiCheckbox-root-11 ActionsArea-checkBoxRoot-3 MuiCheckbox-colorPrimary-15"
+              className="MuiButtonBase-root-28 MuiIconButton-root-22 MuiPrivateSwitchBase-root-18 MuiCheckbox-root-12 ActionsArea-checkBoxRoot-3 MuiCheckbox-colorPrimary-16"
               onBlur={[Function]}
               onContextMenu={[Function]}
               onFocus={[Function]}
@@ -622,11 +611,11 @@ exports[`VerseCheck component: Integrated View test 1`] = `
               tabIndex={null}
             >
               <span
-                className="MuiIconButton-label-26"
+                className="MuiIconButton-label-27"
               >
                 <svg
                   aria-hidden="true"
-                  className="MuiSvgIcon-root-30"
+                  className="MuiSvgIcon-root-31"
                   focusable="false"
                   role="presentation"
                   viewBox="0 0 24 24"
@@ -637,7 +626,7 @@ exports[`VerseCheck component: Integrated View test 1`] = `
                 </svg>
                 <input
                   checked={false}
-                  className="MuiPrivateSwitchBase-input-20"
+                  className="MuiPrivateSwitchBase-input-21"
                   data-indeterminate={false}
                   disabled={false}
                   onChange={[Function]}
@@ -646,19 +635,49 @@ exports[`VerseCheck component: Integrated View test 1`] = `
                 />
               </span>
               <span
-                className="MuiTouchRipple-root-91"
+                className="MuiTouchRipple-root-92"
               />
             </span>
             <span
-              className="MuiTypography-root-39 MuiTypography-body1-48 MuiFormControlLabel-label-10 ActionsArea-label-2"
+              className="MuiTypography-root-40 MuiTypography-body1-49 MuiFormControlLabel-label-11 ActionsArea-label-2"
             >
               No selection needed
             </span>
           </label>
           <div
-            className="__react_component_tooltip place-top type-dark "
-            data-id="tooltip"
-          />
+            data-class="selection-tooltip"
+            data-delay-hide="100"
+            data-effect="float"
+            data-place="top"
+            data-tip="nothing_to_select_description"
+            data-type="dark"
+            style={
+              Object {
+                "fontSize": "0.8em",
+                "verticalAlign": "super",
+              }
+            }
+          >
+            <svg
+              aria-hidden="true"
+              className="MuiSvgIcon-root-31 ActionsArea-icon-5"
+              focusable="false"
+              role="presentation"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M0 0h24v24H0z"
+                fill="none"
+              />
+              <path
+                d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z"
+              />
+            </svg>
+            <div
+              className="__react_component_tooltip place-top type-dark "
+              data-id="tooltip"
+            />
+          </div>
         </div>
         <div>
           <button
@@ -1030,7 +1049,7 @@ exports[`VerseCheck component: Integrated View test with default and invalidated
         className="actions-area"
       >
         <label
-          className="MuiFormControlLabel-root-5"
+          className="MuiFormControlLabel-root-6"
           style={
             Object {
               "paddingLeft": 10,
@@ -1038,10 +1057,10 @@ exports[`VerseCheck component: Integrated View test with default and invalidated
           }
         >
           <span
-            className="MuiSwitch-root-100"
+            className="MuiSwitch-root-101"
           >
             <span
-              className="MuiButtonBase-root-27 MuiIconButton-root-21 MuiPrivateSwitchBase-root-17 MuiSwitch-switchBase-103 MuiSwitch-colorPrimary-105 Bookmark-colorPrimary-99"
+              className="MuiButtonBase-root-28 MuiIconButton-root-22 MuiPrivateSwitchBase-root-18 MuiSwitch-switchBase-104 MuiSwitch-colorPrimary-106 Bookmark-colorPrimary-100"
               onBlur={[Function]}
               onContextMenu={[Function]}
               onFocus={[Function]}
@@ -1056,14 +1075,14 @@ exports[`VerseCheck component: Integrated View test with default and invalidated
               tabIndex={null}
             >
               <span
-                className="MuiIconButton-label-26"
+                className="MuiIconButton-label-27"
               >
                 <span
-                  className="MuiSwitch-icon-101"
+                  className="MuiSwitch-icon-102"
                 />
                 <input
                   checked={false}
-                  className="MuiPrivateSwitchBase-input-20"
+                  className="MuiPrivateSwitchBase-input-21"
                   disabled={false}
                   onChange={[Function]}
                   type="checkbox"
@@ -1071,15 +1090,15 @@ exports[`VerseCheck component: Integrated View test with default and invalidated
                 />
               </span>
               <span
-                className="MuiTouchRipple-root-91"
+                className="MuiTouchRipple-root-92"
               />
             </span>
             <span
-              className="MuiSwitch-bar-108"
+              className="MuiSwitch-bar-109"
             />
           </span>
           <span
-            className="MuiTypography-root-39 MuiTypography-body1-48 MuiFormControlLabel-label-10 Bookmark-label-98"
+            className="MuiTypography-root-40 MuiTypography-body1-49 MuiFormControlLabel-label-11 Bookmark-label-99"
           >
             bookmark
           </span>
@@ -1483,24 +1502,13 @@ exports[`VerseCheck component: Integrated View test with invalidated 1`] = `
         className="selection-actions-area"
       >
         <div
-          data-class="selection-tooltip"
-          data-delay-hide="100"
-          data-effect="float"
-          data-place="top"
-          data-tip="nothing_to_select_description"
-          data-type="dark"
-          style={
-            Object {
-              "fontSize": "0.8em",
-              "verticalAlign": "super",
-            }
-          }
+          className="flex-row"
         >
           <label
-            className="MuiFormControlLabel-root-5 ActionsArea-formControl-1"
+            className="MuiFormControlLabel-root-6 ActionsArea-formControl-1"
           >
             <span
-              className="MuiButtonBase-root-27 MuiIconButton-root-21 MuiPrivateSwitchBase-root-17 MuiCheckbox-root-11 ActionsArea-checkBoxRoot-3 MuiCheckbox-colorPrimary-15"
+              className="MuiButtonBase-root-28 MuiIconButton-root-22 MuiPrivateSwitchBase-root-18 MuiCheckbox-root-12 ActionsArea-checkBoxRoot-3 MuiCheckbox-colorPrimary-16"
               onBlur={[Function]}
               onContextMenu={[Function]}
               onFocus={[Function]}
@@ -1515,11 +1523,11 @@ exports[`VerseCheck component: Integrated View test with invalidated 1`] = `
               tabIndex={null}
             >
               <span
-                className="MuiIconButton-label-26"
+                className="MuiIconButton-label-27"
               >
                 <svg
                   aria-hidden="true"
-                  className="MuiSvgIcon-root-30"
+                  className="MuiSvgIcon-root-31"
                   focusable="false"
                   role="presentation"
                   viewBox="0 0 24 24"
@@ -1530,7 +1538,7 @@ exports[`VerseCheck component: Integrated View test with invalidated 1`] = `
                 </svg>
                 <input
                   checked={false}
-                  className="MuiPrivateSwitchBase-input-20"
+                  className="MuiPrivateSwitchBase-input-21"
                   data-indeterminate={false}
                   disabled={false}
                   onChange={[Function]}
@@ -1539,19 +1547,49 @@ exports[`VerseCheck component: Integrated View test with invalidated 1`] = `
                 />
               </span>
               <span
-                className="MuiTouchRipple-root-91"
+                className="MuiTouchRipple-root-92"
               />
             </span>
             <span
-              className="MuiTypography-root-39 MuiTypography-body1-48 MuiFormControlLabel-label-10 ActionsArea-label-2"
+              className="MuiTypography-root-40 MuiTypography-body1-49 MuiFormControlLabel-label-11 ActionsArea-label-2"
             >
               No selection needed
             </span>
           </label>
           <div
-            className="__react_component_tooltip place-top type-dark "
-            data-id="tooltip"
-          />
+            data-class="selection-tooltip"
+            data-delay-hide="100"
+            data-effect="float"
+            data-place="top"
+            data-tip="nothing_to_select_description"
+            data-type="dark"
+            style={
+              Object {
+                "fontSize": "0.8em",
+                "verticalAlign": "super",
+              }
+            }
+          >
+            <svg
+              aria-hidden="true"
+              className="MuiSvgIcon-root-31 ActionsArea-icon-5"
+              focusable="false"
+              role="presentation"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M0 0h24v24H0z"
+                fill="none"
+              />
+              <path
+                d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z"
+              />
+            </svg>
+            <div
+              className="__react_component_tooltip place-top type-dark "
+              data-id="tooltip"
+            />
+          </div>
         </div>
         <div>
           <button
@@ -1799,24 +1837,13 @@ exports[`VerseCheck component: Integrated View test with verseEdit 1`] = `
         className="selection-actions-area"
       >
         <div
-          data-class="selection-tooltip"
-          data-delay-hide="100"
-          data-effect="float"
-          data-place="top"
-          data-tip="nothing_to_select_description"
-          data-type="dark"
-          style={
-            Object {
-              "fontSize": "0.8em",
-              "verticalAlign": "super",
-            }
-          }
+          className="flex-row"
         >
           <label
-            className="MuiFormControlLabel-root-5 ActionsArea-formControl-1"
+            className="MuiFormControlLabel-root-6 ActionsArea-formControl-1"
           >
             <span
-              className="MuiButtonBase-root-27 MuiIconButton-root-21 MuiPrivateSwitchBase-root-17 MuiCheckbox-root-11 ActionsArea-checkBoxRoot-3 MuiCheckbox-colorPrimary-15"
+              className="MuiButtonBase-root-28 MuiIconButton-root-22 MuiPrivateSwitchBase-root-18 MuiCheckbox-root-12 ActionsArea-checkBoxRoot-3 MuiCheckbox-colorPrimary-16"
               onBlur={[Function]}
               onContextMenu={[Function]}
               onFocus={[Function]}
@@ -1831,11 +1858,11 @@ exports[`VerseCheck component: Integrated View test with verseEdit 1`] = `
               tabIndex={null}
             >
               <span
-                className="MuiIconButton-label-26"
+                className="MuiIconButton-label-27"
               >
                 <svg
                   aria-hidden="true"
-                  className="MuiSvgIcon-root-30"
+                  className="MuiSvgIcon-root-31"
                   focusable="false"
                   role="presentation"
                   viewBox="0 0 24 24"
@@ -1846,7 +1873,7 @@ exports[`VerseCheck component: Integrated View test with verseEdit 1`] = `
                 </svg>
                 <input
                   checked={false}
-                  className="MuiPrivateSwitchBase-input-20"
+                  className="MuiPrivateSwitchBase-input-21"
                   data-indeterminate={false}
                   disabled={false}
                   onChange={[Function]}
@@ -1855,19 +1882,49 @@ exports[`VerseCheck component: Integrated View test with verseEdit 1`] = `
                 />
               </span>
               <span
-                className="MuiTouchRipple-root-91"
+                className="MuiTouchRipple-root-92"
               />
             </span>
             <span
-              className="MuiTypography-root-39 MuiTypography-body1-48 MuiFormControlLabel-label-10 ActionsArea-label-2"
+              className="MuiTypography-root-40 MuiTypography-body1-49 MuiFormControlLabel-label-11 ActionsArea-label-2"
             >
               No selection needed
             </span>
           </label>
           <div
-            className="__react_component_tooltip place-top type-dark "
-            data-id="tooltip"
-          />
+            data-class="selection-tooltip"
+            data-delay-hide="100"
+            data-effect="float"
+            data-place="top"
+            data-tip="nothing_to_select_description"
+            data-type="dark"
+            style={
+              Object {
+                "fontSize": "0.8em",
+                "verticalAlign": "super",
+              }
+            }
+          >
+            <svg
+              aria-hidden="true"
+              className="MuiSvgIcon-root-31 ActionsArea-icon-5"
+              focusable="false"
+              role="presentation"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M0 0h24v24H0z"
+                fill="none"
+              />
+              <path
+                d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z"
+              />
+            </svg>
+            <div
+              className="__react_component_tooltip place-top type-dark "
+              data-id="tooltip"
+            />
+          </div>
         </div>
         <div>
           <button

--- a/src/VerseEditor/BaseDialog.js
+++ b/src/VerseEditor/BaseDialog.js
@@ -5,12 +5,19 @@ import DialogTitle from '@material-ui/core/DialogTitle';
 import DialogActions from '@material-ui/core/DialogActions';
 import DialogContent from '@material-ui/core/DialogContent';
 import {withStyles} from '@material-ui/core/styles';
+import Paper from '@material-ui/core/Paper';
+import Draggable from 'react-draggable';
+
+function PaperComponent(props) {
+  // component will only be draggable by element with the className in the handle prop
+  return (
+    <Draggable handle=".BaseDialog-draggable-handle">
+      <Paper {...props} />
+    </Draggable>
+  );
+}
 /**
  * Generates the dialog actions
- *
- * This was copied from tC core.
- * here should be a better way to provide a consistent dialog experience across tools.
- *
  * @param {bool} actionsEnabled enables/disables the action buttons
  * @param {*} primaryLabel the title of the primary button
  * @param {*} secondaryLabel the title of the secondary button
@@ -104,11 +111,15 @@ class BaseDialog extends React.Component {
 
     return (
       <Dialog
-        fullWidth={true}
         open={open}
-        onClose={onClose}>
+        onClose={onClose}
+        fullWidth={true}
+        PaperComponent={PaperComponent}
+        aria-labelledby={`draggable-${title}-dialog`}
+      >
         <DialogTitle
           disableTypography={true}
+          className="BaseDialog-draggable-handle"
           style={{
             color: 'var(--reverse-color)',
             backgroundColor: 'var(--accent-color-dark)',
@@ -116,7 +127,8 @@ class BaseDialog extends React.Component {
             display: 'block',
             width: '100%',
             fontSize: 22,
-            fontWeight: 400
+            fontWeight: 400,
+            cursor: 'move'
           }}>
           {title}
         </DialogTitle>

--- a/src/VerseEditor/VerseEditor.js
+++ b/src/VerseEditor/VerseEditor.js
@@ -164,12 +164,15 @@ class VerseEditor extends React.Component {
     );
 
     return (
-      <BaseDialog modal={true}
+      <BaseDialog
+        modal={true}
         open={open}
-        title={title}>
-        <VerseEditorStepper stepIndex={stepIndex}
+        title={title}
+      >
+        <VerseEditorStepper
+          stepIndex={stepIndex}
           className='stepper'
-          steps={localizedSteps} />
+          steps={localizedSteps}/>
         <div className='screen'>
           {screen}
         </div>


### PR DESCRIPTION
- Added info icon to "no selection needed" checkbox
- Made expanded scripture pane and verse editor dialogs draggable

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/translationcoreapps/tc-ui-toolkit/208)
<!-- Reviewable:end -->
