### PR TITLE
Feature 6193/Support for more than one original language.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tc-ui-toolkit",
-  "version": "0.14.18",
+  "version": "0.14.19",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tc-ui-toolkit",
-  "version": "0.14.18",
+  "version": "0.14.19",
   "description": "React components used to develop tools for the desktop app translationCore",
   "main": "dist/bundle.js",
   "display": "library",

--- a/src/ScripturePane/ScripturePane.js
+++ b/src/ScripturePane/ScripturePane.js
@@ -108,7 +108,7 @@ class ScripturePane extends Component {
         let description = manifest.description;
         if (languageId === "originalLanguage") {
           if (description !== "original_language") {
-            description = translate("original_language");
+            description = "original_language";
           }
         }
 

--- a/src/ScripturePane/ScripturePane.js
+++ b/src/ScripturePane/ScripturePane.js
@@ -107,9 +107,7 @@ class ScripturePane extends Component {
         }
         let description = manifest.description;
         if (languageId === "originalLanguage") {
-          if (description !== "original_language") {
-            description = "original_language";
-          }
+          description = "original_language";
         }
 
         if (typeof verseData === 'string') { // if the verse content is string.

--- a/src/ScripturePane/ScripturePane.js
+++ b/src/ScripturePane/ScripturePane.js
@@ -107,8 +107,8 @@ class ScripturePane extends Component {
         }
         let description = manifest.description;
         if (languageId === "originalLanguage") {
-          if (description !== "originalLanguage") {
-            description = "originalLanguage";
+          if (description !== "original_language") {
+            description = "original_language";
           }
         }
 

--- a/src/ScripturePane/ScripturePane.js
+++ b/src/ScripturePane/ScripturePane.js
@@ -105,6 +105,12 @@ class ScripturePane extends Component {
         if ((languageId === "targetLanguage") && (bibleId === "targetBible")) { // if target bible/language, pull up actual name
           language_name = manifest.language_name + " (" + manifest.language_id.toUpperCase() + ")";
         }
+        let description = manifest.description;
+        if (languageId === "originalLanguage") {
+          if (description !== "originalLanguage") {
+            description = "originalLanguage";
+          }
+        }
 
         if (typeof verseData === 'string') { // if the verse content is string.
           verseElements = verseString(verseData, selections, translate, setFontSize);
@@ -122,7 +128,7 @@ class ScripturePane extends Component {
             bibleId={bibleId}
             languageName={language_name}
             direction={manifest.direction}
-            description={manifest.description}
+            description={description}
             verseElements={verseElements}
             clickToRemoveResourceLabel={translate('pane.remove_resource')}
             removePane={this.removePane}

--- a/src/ScripturePane/ScripturePane.js
+++ b/src/ScripturePane/ScripturePane.js
@@ -108,7 +108,7 @@ class ScripturePane extends Component {
         let description = manifest.description;
         if (languageId === "originalLanguage") {
           if (description !== "original_language") {
-            description = "original_language";
+            description = translate("original_language");
           }
         }
 


### PR DESCRIPTION
- override description of additional original language resources to show original language instead of gateway language.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/translationcoreapps/tc-ui-toolkit/216)
<!-- Reviewable:end -->
