### PR TITLE
Refactored verseCheck to use explicit props instead of entire reducers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tc-ui-toolkit",
-  "version": "0.15.00",
+  "version": "0.15.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tc-ui-toolkit",
-  "version": "0.14.38",
+  "version": "0.15.00",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tc-ui-toolkit",
-  "version": "0.15.00",
+  "version": "0.15.0",
   "description": "React components used to develop tools for the desktop app translationCore",
   "main": "dist/bundle.js",
   "display": "library",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tc-ui-toolkit",
-  "version": "0.14.38",
+  "version": "0.15.00",
   "description": "React components used to develop tools for the desktop app translationCore",
   "main": "dist/bundle.js",
   "display": "library",

--- a/src/TranslationHelps/TranslationHelps.js
+++ b/src/TranslationHelps/TranslationHelps.js
@@ -80,6 +80,10 @@ TranslationHelps.propTypes = {
   translate: PropTypes.func.isRequired,
 };
 
-TranslationHelps.defaultProps = { modalTitle: 'translationHelps' };
+TranslationHelps.defaultProps = {
+  modalTitle: 'translationHelps',
+  article: '',
+  modalArticle: '',
+};
 
 export default TranslationHelps;

--- a/src/VerseCheck/ActionsArea/index.js
+++ b/src/VerseCheck/ActionsArea/index.js
@@ -1,11 +1,11 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { Glyphicon } from 'react-bootstrap';
 import isEqual from 'deep-equal';
 import Checkbox from '@material-ui/core/Checkbox';
 import { withStyles } from '@material-ui/core/styles';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 import InfoIcon from '@material-ui/icons/Info';
-
 import ReactTooltip from 'react-tooltip';
 // components
 import Bookmark from '../../Bookmark';
@@ -44,14 +44,182 @@ const isSelectionsSaveDisable = (localNothingToSelect, nothingToSelect, newSelec
   return localNothingToSelect === nothingToSelect;
 };
 
-let ActionsArea = ({
+/* eslint-disable react/prop-types */
+const ChangeModeArea = ({
+  translate,
+  bookmarkEnabled,
+  toggleReminder,
+  changeMode,
+}) => (
+  <div className='actions-area'>
+    <Bookmark
+      value='bookmark'
+      color='primary'
+      checked={bookmarkEnabled}
+      label={translate('bookmark')}
+      onChange={toggleReminder} />
+    <div style={{ display: 'flex', marginLeft: 'auto' }}>
+      <button
+        style={{ width: '140px', marginRight: '5px' }}
+        className='btn-second'
+        onClick={() => changeMode('select')}
+      >
+        <Glyphicon glyph='ok' style={{ marginRight: '10px' }} />
+        {translate('select')}
+      </button>
+      <button
+        style={{ width: '140px', marginRight: '5px' }}
+        className='btn-second'
+        onClick={() => changeMode('edit')}
+      >
+        <Glyphicon glyph='pencil' style={{ marginRight: '10px' }} />
+        {translate('edit_verse')}
+      </button>
+      <button
+        style={{ width: '140px' }}
+        className='btn-second'
+        onClick={() => changeMode('comment')}
+      >
+        <Glyphicon glyph='comment' style={{ marginRight: '10px' }} />
+        {translate('comment')}
+      </button>
+    </div>
+  </div>
+);
+
+const ConfirmEditVerseArea = ({
+  translate,
+  tags,
+  cancelEditVerse,
+  saveEditVerse,
+}) => (
+  <div className='actions-area'>
+    <button
+      className='btn-second'
+      onClick={cancelEditVerse}
+    >
+      {translate('cancel')}
+    </button>
+    <button className='btn-prime'
+      disabled={!tags.length}
+      onClick={saveEditVerse}
+    >
+      <Glyphicon glyph='ok' style={{ marginRight: '10px' }} />
+      {translate('save')}
+    </button>
+  </div>
+);
+
+const ConfirmCommentArea = ({
+  translate,
+  commentChanged,
+  cancelComment,
+  saveComment,
+}) => (
+  <div className='actions-area'>
+    <button className='btn-second'
+      onClick={cancelComment}
+    >
+      {translate('cancel')}
+    </button>
+    <button className='btn-prime'
+      disabled={!commentChanged}
+      onClick={saveComment}
+    >
+      <Glyphicon glyph='ok' style={{ marginRight: '10px' }} />
+      {translate('save')}
+    </button>
+  </div>
+);
+
+const ConfirmSelectionArea = ({
+  classes,
+  translate,
+  localNothingToSelect,
+  newSelections,
+  nothingToSelect,
+  selections,
+  toggleNothingToSelect,
+  cancelSelection,
+  clearSelection,
+  saveSelection,
+}) => (
+  <div className='selection-actions-area'>
+    <div className='flex-row'>
+      <FormControlLabel
+        value="end"
+        control={
+          <Checkbox
+            checked={localNothingToSelect}
+            disabled={newSelections && newSelections.length > 0}
+            onChange={event => toggleNothingToSelect(event.target.checked)}
+            value="nothingToSelect"
+            color="primary"
+            classes={{
+              root: classes.checkBoxRoot,
+              checked: classes.checked,
+            }}
+          />
+        }
+        label="No selection needed"
+        classes={{
+          root: classes.formControl,
+          label: classes.label,
+        }}
+      />
+      <div
+        data-tip={translate('nothing_to_select_description')}
+        data-place="top"
+        data-effect="float"
+        data-type="dark"
+        data-class="selection-tooltip"
+        data-delay-hide="100"
+        style={{ verticalAlign: 'super', fontSize: '0.8em' }}
+      >
+        <InfoIcon classes={{ root: classes.icon }} />
+        <ReactTooltip/>
+      </div>
+    </div>
+    <div style={{ whiteSpace: 'nowrap' }}>
+      <button
+        className='btn-second'
+        style={{
+          marginLeft: '0px', width: '140px', marginRight: '5px', alignSelf: 'flex-start',
+        }}
+        onClick={cancelSelection}
+      >
+        {translate('cancel')}
+      </button>
+      <button
+        className='btn-second'
+        style={{ width: '140px', marginRight: '5px' }}
+        disabled={newSelections.length > 0 ? false : true}
+        onClick={clearSelection}
+      >
+        <Glyphicon glyph='erase' style={{ marginRight: '10px' }} />
+        {translate('clear_selection')}
+      </button>
+      <button
+        className='btn-prime'
+        style={{ width: '140px', marginRight: '5px' }}
+        disabled={isSelectionsSaveDisable(localNothingToSelect, nothingToSelect, newSelections, selections)}
+        onClick={saveSelection}
+      >
+        <Glyphicon glyph='ok' style={{ marginRight: '10px' }} />
+        {translate('save')}
+      </button>
+    </div>
+  </div>
+);
+/* eslint-enable react/prop-types */
+
+const ActionsArea = ({
   tags,
   mode,
-  actions,
   commentChanged,
   selections,
   newSelections,
-  remindersReducer,
+  bookmarkEnabled,
   saveSelection,
   cancelSelection,
   clearSelection,
@@ -60,167 +228,89 @@ let ActionsArea = ({
   localNothingToSelect,
   nothingToSelect,
   toggleNothingToSelect,
+  toggleReminder,
+  changeMode,
+  cancelEditVerse,
+  saveEditVerse,
+  cancelComment,
+  saveComment,
 }) => {
-  const changeModeArea = (
-    <div className='actions-area'>
-      <Bookmark
-        value='bookmark'
-        color='primary'
-        checked={remindersReducer.enabled}
-        label={translate('bookmark')}
-        onChange={actions.toggleReminder} />
-      <div style={{ display: 'flex', marginLeft: 'auto' }}>
-        <button
-          style={{ width: '140px', marginRight: '5px' }}
-          className='btn-second'
-          onClick={actions.changeMode.bind(this, 'select')}
-        >
-          <Glyphicon glyph='ok' style={{ marginRight: '10px' }} />
-          {translate('select')}
-        </button>
-        <button
-          style={{ width: '140px', marginRight: '5px' }}
-          className='btn-second'
-          onClick={actions.changeMode.bind(this, 'edit')}
-        >
-          <Glyphicon glyph='pencil' style={{ marginRight: '10px' }} />
-          {translate('edit_verse')}
-        </button>
-        <button
-          style={{ width: '140px' }}
-          className='btn-second'
-          onClick={actions.changeMode.bind(this, 'comment')}
-        >
-          <Glyphicon glyph='comment' style={{ marginRight: '10px' }} />
-          {translate('comment')}
-        </button>
-      </div>
-    </div>
-  );
-
-  const confirmEditVerseArea = (
-    <div className='actions-area'>
-      <button
-        className='btn-second'
-        onClick={actions.cancelEditVerse.bind(this)}
-      >
-        {translate('cancel')}
-      </button>
-      <button className='btn-prime'
-        disabled={!tags.length}
-        onClick={actions.saveEditVerse.bind(this)}
-      >
-        <Glyphicon glyph='ok' style={{ marginRight: '10px' }} />
-        {translate('save')}
-      </button>
-    </div>
-  );
-
-  const confirmCommentArea = (
-    <div className='actions-area'>
-      <button className='btn-second'
-        onClick={actions.cancelComment.bind(this)}
-      >
-        {translate('cancel')}
-      </button>
-      <button className='btn-prime'
-        disabled={!commentChanged}
-        onClick={actions.saveComment.bind(this)}
-      >
-        <Glyphicon glyph='ok' style={{ marginRight: '10px' }} />
-        {translate('save')}
-      </button>
-    </div>
-  );
-  const confirmSelectionArea = (
-    <div className='selection-actions-area'>
-      <div className='flex-row'>
-        <FormControlLabel
-          value="end"
-          control={
-            <Checkbox
-              checked={localNothingToSelect}
-              disabled={newSelections && newSelections.length > 0}
-              onChange={event => toggleNothingToSelect(event.target.checked)}
-              value="nothingToSelect"
-              color="primary"
-              classes={{
-                root: classes.checkBoxRoot,
-                checked: classes.checked,
-              }}
-            />
-          }
-          label="No selection needed"
-          classes={{
-            root: classes.formControl,
-            label: classes.label,
-          }}
-        />
-        <div
-          data-tip={translate('nothing_to_select_description')}
-          data-place="top"
-          data-effect="float"
-          data-type="dark"
-          data-class="selection-tooltip"
-          data-delay-hide="100"
-          style={{ verticalAlign: 'super', fontSize: '0.8em' }}
-        >
-          <InfoIcon classes={{ root: classes.icon }} />
-          <ReactTooltip/>
-        </div>
-      </div>
-      <div style={{ whiteSpace: 'nowrap' }}>
-        <button
-          className='btn-second'
-          style={{
-            marginLeft: '0px', width: '140px', marginRight: '5px', alignSelf: 'flex-start',
-          }}
-          onClick={cancelSelection.bind(this)}
-        >
-          {translate('cancel')}
-        </button>
-        <button
-          className='btn-second'
-          style={{ width: '140px', marginRight: '5px' }}
-          disabled={newSelections.length > 0 ? false : true}
-          onClick={clearSelection.bind(this)}
-        >
-          <Glyphicon glyph='erase' style={{ marginRight: '10px' }} />
-          {translate('clear_selection')}
-        </button>
-        <button
-          className='btn-prime'
-          style={{ width: '140px', marginRight: '5px' }}
-          disabled={isSelectionsSaveDisable(localNothingToSelect, nothingToSelect, newSelections, selections)}
-          onClick={saveSelection.bind(this)}
-        >
-          <Glyphicon glyph='ok' style={{ marginRight: '10px' }} />
-          {translate('save')}
-        </button>
-      </div>
-    </div>
-  );
-
-  let modeArea;
-
   switch (mode) {
   case 'edit':
-    modeArea = confirmEditVerseArea;
-    break;
+    return (
+      <ConfirmEditVerseArea
+        tags={tags}
+        translate={translate}
+        cancelEditVerse={cancelEditVerse}
+        saveEditVerse={saveEditVerse}
+      />
+    );
   case 'comment':
-    modeArea = confirmCommentArea;
-    break;
+    return (
+      <ConfirmCommentArea
+        translate={translate}
+        commentChanged={commentChanged}
+        cancelComment={cancelComment}
+        saveComment={saveComment}
+      />
+    );
   case 'select':
-    modeArea = confirmSelectionArea;
-    break;
+    return (
+      <ConfirmSelectionArea
+        classes={classes}
+        translate={translate}
+        localNothingToSelect={localNothingToSelect}
+        newSelections={newSelections}
+        nothingToSelect={nothingToSelect}
+        selections={selections}
+        toggleNothingToSelect={toggleNothingToSelect}
+        cancelSelection={cancelSelection}
+        clearSelection={clearSelection}
+        saveSelection={saveSelection}
+      />
+    );
   case 'default':
-    modeArea = changeModeArea;
-    break;
+    return (
+      <ChangeModeArea
+        translate={translate}
+        bookmarkEnabled={bookmarkEnabled}
+        toggleReminder={toggleReminder}
+        changeMode={changeMode}
+      />
+    );
   default:
-    modeArea = changeModeArea;
+    return (
+      <ChangeModeArea
+        translate={translate}
+        bookmarkEnabled={bookmarkEnabled}
+        toggleReminder={toggleReminder}
+        changeMode={changeMode}
+      />
+    );
   }
+};
 
-  return modeArea;
+ActionsArea.propTypes = {
+  tags: PropTypes.array.isRequired,
+  mode: PropTypes.string.isRequired,
+  commentChanged: PropTypes.bool.isRequired,
+  selections: PropTypes.array.isRequired,
+  newSelections: PropTypes.array.isRequired,
+  bookmarkEnabled: PropTypes.bool.isRequired,
+  classes: PropTypes.object.isRequired,
+  localNothingToSelect: PropTypes.bool.isRequired,
+  nothingToSelect: PropTypes.bool.isRequired,
+  saveSelection: PropTypes.func.isRequired,
+  cancelSelection: PropTypes.func.isRequired,
+  clearSelection: PropTypes.func.isRequired,
+  translate: PropTypes.func.isRequired,
+  toggleNothingToSelect: PropTypes.func.isRequired,
+  toggleReminder: PropTypes.func.isRequired,
+  changeMode: PropTypes.func.isRequired,
+  cancelEditVerse: PropTypes.func.isRequired,
+  saveEditVerse: PropTypes.func.isRequired,
+  cancelComment: PropTypes.func.isRequired,
+  saveComment: PropTypes.func.isRequired,
 };
 
 export default withStyles(styles)(ActionsArea);

--- a/src/VerseCheck/ActionsArea/index.js
+++ b/src/VerseCheck/ActionsArea/index.js
@@ -112,7 +112,7 @@ const ConfirmEditVerseArea = ({
 
 const ConfirmCommentArea = ({
   translate,
-  commentChanged,
+  isCommentChanged,
   cancelComment,
   saveComment,
 }) => (
@@ -123,7 +123,7 @@ const ConfirmCommentArea = ({
       {translate('cancel')}
     </button>
     <button className='btn-prime'
-      disabled={!commentChanged}
+      disabled={!isCommentChanged}
       onClick={saveComment}
     >
       <Glyphicon glyph='ok' style={{ marginRight: '10px' }} />
@@ -216,7 +216,7 @@ const ConfirmSelectionArea = ({
 const ActionsArea = ({
   tags,
   mode,
-  commentChanged,
+  isCommentChanged,
   selections,
   newSelections,
   bookmarkEnabled,
@@ -249,7 +249,7 @@ const ActionsArea = ({
     return (
       <ConfirmCommentArea
         translate={translate}
-        commentChanged={commentChanged}
+        isCommentChanged={isCommentChanged}
         cancelComment={cancelComment}
         saveComment={saveComment}
       />
@@ -293,7 +293,7 @@ const ActionsArea = ({
 ActionsArea.propTypes = {
   tags: PropTypes.array.isRequired,
   mode: PropTypes.string.isRequired,
-  commentChanged: PropTypes.bool.isRequired,
+  isCommentChanged: PropTypes.bool.isRequired,
   selections: PropTypes.array.isRequired,
   newSelections: PropTypes.array.isRequired,
   bookmarkEnabled: PropTypes.bool.isRequired,

--- a/src/VerseCheck/CheckArea/index.js
+++ b/src/VerseCheck/CheckArea/index.js
@@ -14,7 +14,7 @@ const CheckArea = ({
   tags,
   verseText,
   unfilteredVerseText,
-  verseChanged,
+  isVerseChanged,
   comment,
   newSelections,
   selections,
@@ -26,9 +26,9 @@ const CheckArea = ({
   maximumSelections,
   handleTagsCheckbox,
   handleEditVerse,
-  hasVerseChanged,
+  checkIfVerseChanged,
   handleComment,
-  hasCommentChanged,
+  checkIfCommentChanged,
   openAlertDialog,
   changeSelectionsInLocalState,
   validateSelections,
@@ -44,10 +44,10 @@ const CheckArea = ({
       <EditVerseArea
         tags={tags}
         verseText={unfilteredVerseText}
-        verseChanged={verseChanged}
+        isVerseChanged={isVerseChanged}
         handleTagsCheckbox={handleTagsCheckbox}
         handleEditVerse={handleEditVerse}
-        hasVerseChanged={hasVerseChanged}
+        checkIfVerseChanged={checkIfVerseChanged}
         languageDirection={languageDirection}
         translate={translate}
       />
@@ -59,7 +59,7 @@ const CheckArea = ({
         comment={comment}
         translate={translate}
         handleComment={handleComment}
-        hasCommentChanged={hasCommentChanged}
+        checkIfCommentChanged={checkIfCommentChanged}
       />
     );
     break;
@@ -140,7 +140,7 @@ CheckArea.propTypes = {
   invalidated: PropTypes.bool.isRequired,
   verseText: PropTypes.string.isRequired,
   unfilteredVerseText: PropTypes.string.isRequired,
-  verseChanged: PropTypes.bool.isRequired,
+  isVerseChanged: PropTypes.bool.isRequired,
   comment: PropTypes.string.isRequired,
   contextId: PropTypes.object.isRequired,
   selections: PropTypes.array.isRequired,
@@ -153,9 +153,9 @@ CheckArea.propTypes = {
   targetLanguageDetails: PropTypes.object.isRequired,
   handleTagsCheckbox: PropTypes.func.isRequired,
   handleEditVerse: PropTypes.func.isRequired,
-  hasVerseChanged: PropTypes.func.isRequired,
   handleComment: PropTypes.func.isRequired,
-  hasCommentChanged: PropTypes.func.isRequired,
+  checkIfVerseChanged: PropTypes.func.isRequired,
+  checkIfCommentChanged: PropTypes.func.isRequired,
   openAlertDialog: PropTypes.func.isRequired,
   changeSelectionsInLocalState: PropTypes.func.isRequired,
   validateSelections: PropTypes.func.isRequired,

--- a/src/VerseCheck/CheckArea/index.js
+++ b/src/VerseCheck/CheckArea/index.js
@@ -26,7 +26,7 @@ const CheckArea = ({
   maximumSelections,
   handleTagsCheckbox,
   handleEditVerse,
-  handleCheckVerse,
+  hasVerseChanged,
   handleComment,
   hasCommentChanged,
   openAlertDialog,
@@ -47,7 +47,7 @@ const CheckArea = ({
         verseChanged={verseChanged}
         handleTagsCheckbox={handleTagsCheckbox}
         handleEditVerse={handleEditVerse}
-        handleCheckVerse={handleCheckVerse}
+        hasVerseChanged={hasVerseChanged}
         languageDirection={languageDirection}
         translate={translate}
       />
@@ -153,7 +153,7 @@ CheckArea.propTypes = {
   targetLanguageDetails: PropTypes.object.isRequired,
   handleTagsCheckbox: PropTypes.func.isRequired,
   handleEditVerse: PropTypes.func.isRequired,
-  handleCheckVerse: PropTypes.func.isRequired,
+  hasVerseChanged: PropTypes.func.isRequired,
   handleComment: PropTypes.func.isRequired,
   hasCommentChanged: PropTypes.func.isRequired,
   openAlertDialog: PropTypes.func.isRequired,

--- a/src/VerseCheck/CheckArea/index.js
+++ b/src/VerseCheck/CheckArea/index.js
@@ -20,7 +20,7 @@ const CheckArea = ({
   selections,
   translate,
   invalidated,
-  bibles,
+  targetBible,
   alignedGLText,
   nothingToSelect,
   maximumSelections,
@@ -118,7 +118,7 @@ const CheckArea = ({
           translate={translate}
           verseText={verseText}
           selections={selections}
-          bibles={bibles}
+          targetBible={targetBible}
           validateSelections={validateSelections}
           bookDetails={bookDetails}
           targetLanguageDetails={targetLanguageDetails}
@@ -142,10 +142,10 @@ CheckArea.propTypes = {
   unfilteredVerseText: PropTypes.string.isRequired,
   verseChanged: PropTypes.bool.isRequired,
   comment: PropTypes.string.isRequired,
-  contextId: PropTypes.object,
+  contextId: PropTypes.object.isRequired,
   selections: PropTypes.array.isRequired,
   newSelections: PropTypes.array.isRequired,
-  bibles: PropTypes.object,
+  targetBible: PropTypes.object.isRequired,
   alignedGLText: PropTypes.string.isRequired,
   nothingToSelect: PropTypes.bool.isRequired,
   maximumSelections: PropTypes.number.isRequired,

--- a/src/VerseCheck/CheckArea/index.js
+++ b/src/VerseCheck/CheckArea/index.js
@@ -8,9 +8,8 @@ import EditVerseArea from '../EditVerseArea';
 import CommentArea from '../CommentArea';
 import './CheckArea.styles.css';
 
-let CheckArea = ({
+const CheckArea = ({
   contextId,
-  actions,
   mode,
   tags,
   verseText,
@@ -19,15 +18,25 @@ let CheckArea = ({
   comment,
   newSelections,
   selections,
-  projectDetailsReducer,
   translate,
   invalidated,
   bibles,
   alignedGLText,
   nothingToSelect,
   maximumSelections,
+  handleTagsCheckbox,
+  handleEditVerse,
+  handleCheckVerse,
+  handleComment,
+  handleCheckComment,
+  openAlertDialog,
+  changeSelectionsInLocalState,
+  validateSelections,
+  bookDetails,
+  targetLanguageDetails,
 }) => {
   let modeArea;
+  const { direction: languageDirection = 'ltr' } = targetLanguageDetails || {};
 
   switch (mode) {
   case 'edit':
@@ -36,15 +45,23 @@ let CheckArea = ({
         tags={tags}
         verseText={unfilteredVerseText}
         verseChanged={verseChanged}
-        actions={actions}
-        dir={projectDetailsReducer.manifest.target_language.direction}
+        handleTagsCheckbox={handleTagsCheckbox}
+        handleEditVerse={handleEditVerse}
+        handleCheckVerse={handleCheckVerse}
+        languageDirection={languageDirection}
         translate={translate}
-
       />
     );
     break;
   case 'comment':
-    modeArea = <CommentArea comment={comment} actions={actions} translate={translate} />;
+    modeArea = (
+      <CommentArea
+        comment={comment}
+        translate={translate}
+        handleComment={handleComment}
+        handleCheckComment={handleCheckComment}
+      />
+    );
     break;
   case 'select':
     modeArea = (
@@ -88,18 +105,23 @@ let CheckArea = ({
           verseText={verseText}
           selections={newSelections}
           mode={mode}
-          manifest={projectDetailsReducer.manifest}
           reference={contextId.reference}
-          actions={actions}
-          maximumSelections={maximumSelections} /> :
+          maximumSelections={maximumSelections}
+          openAlertDialog={openAlertDialog}
+          changeSelectionsInLocalState={changeSelectionsInLocalState}
+          bookDetails={bookDetails}
+          targetLanguageDetails={targetLanguageDetails}
+        />
+        :
         <DefaultArea
           reference={contextId.reference}
-          actions={actions}
           translate={translate}
-          manifest={projectDetailsReducer.manifest}
           verseText={verseText}
           selections={selections}
           bibles={bibles}
+          validateSelections={validateSelections}
+          bookDetails={bookDetails}
+          targetLanguageDetails={targetLanguageDetails}
         />
       }
       <div style={{
@@ -113,7 +135,6 @@ let CheckArea = ({
 
 CheckArea.propTypes = {
   translate: PropTypes.func.isRequired,
-  actions: PropTypes.object.isRequired,
   mode: PropTypes.string.isRequired,
   tags: PropTypes.array.isRequired,
   invalidated: PropTypes.bool.isRequired,
@@ -124,11 +145,20 @@ CheckArea.propTypes = {
   contextId: PropTypes.object,
   selections: PropTypes.array.isRequired,
   newSelections: PropTypes.array.isRequired,
-  projectDetailsReducer: PropTypes.shape({ manifest: PropTypes.object }).isRequired,
   bibles: PropTypes.object,
   alignedGLText: PropTypes.string.isRequired,
   nothingToSelect: PropTypes.bool.isRequired,
   maximumSelections: PropTypes.number.isRequired,
+  bookDetails: PropTypes.object.isRequired,
+  targetLanguageDetails: PropTypes.object.isRequired,
+  handleTagsCheckbox: PropTypes.func.isRequired,
+  handleEditVerse: PropTypes.func.isRequired,
+  handleCheckVerse: PropTypes.func.isRequired,
+  handleComment: PropTypes.func.isRequired,
+  handleCheckComment: PropTypes.func.isRequired,
+  openAlertDialog: PropTypes.func.isRequired,
+  changeSelectionsInLocalState: PropTypes.func.isRequired,
+  validateSelections: PropTypes.func.isRequired,
 };
 
 export default CheckArea;

--- a/src/VerseCheck/CheckArea/index.js
+++ b/src/VerseCheck/CheckArea/index.js
@@ -28,7 +28,7 @@ const CheckArea = ({
   handleEditVerse,
   handleCheckVerse,
   handleComment,
-  handleCheckComment,
+  hasCommentChanged,
   openAlertDialog,
   changeSelectionsInLocalState,
   validateSelections,
@@ -59,7 +59,7 @@ const CheckArea = ({
         comment={comment}
         translate={translate}
         handleComment={handleComment}
-        handleCheckComment={handleCheckComment}
+        hasCommentChanged={hasCommentChanged}
       />
     );
     break;
@@ -155,7 +155,7 @@ CheckArea.propTypes = {
   handleEditVerse: PropTypes.func.isRequired,
   handleCheckVerse: PropTypes.func.isRequired,
   handleComment: PropTypes.func.isRequired,
-  handleCheckComment: PropTypes.func.isRequired,
+  hasCommentChanged: PropTypes.func.isRequired,
   openAlertDialog: PropTypes.func.isRequired,
   changeSelectionsInLocalState: PropTypes.func.isRequired,
   validateSelections: PropTypes.func.isRequired,

--- a/src/VerseCheck/CommentArea/index.js
+++ b/src/VerseCheck/CommentArea/index.js
@@ -9,7 +9,7 @@ const CommentArea = ({
   comment,
   translate,
   handleComment,
-  handleCheckComment,
+  hasCommentChanged,
 }) => (
   <div className='comment-area'>
     <div style={{ fontWeight: 'bold' }}>
@@ -23,7 +23,7 @@ const CommentArea = ({
         defaultValue={comment}
         style={{ flex: 'auto' }}
         onBlur={handleComment}
-        onInput={handleCheckComment}
+        onInput={hasCommentChanged}
       />
     </FormGroup>
   </div>
@@ -33,7 +33,7 @@ CommentArea.propTypes = {
   translate: PropTypes.func.isRequired,
   comment: PropTypes.string.isRequired,
   handleComment: PropTypes.func.isRequired,
-  handleCheckComment: PropTypes.func.isRequired,
+  hasCommentChanged: PropTypes.func.isRequired,
 };
 
 export default CommentArea;

--- a/src/VerseCheck/CommentArea/index.js
+++ b/src/VerseCheck/CommentArea/index.js
@@ -9,7 +9,7 @@ const CommentArea = ({
   comment,
   translate,
   handleComment,
-  checkIfVerseChanged,
+  checkIfCommentChanged,
 }) => (
   <div className='comment-area'>
     <div style={{ fontWeight: 'bold' }}>
@@ -23,7 +23,7 @@ const CommentArea = ({
         defaultValue={comment}
         style={{ flex: 'auto' }}
         onBlur={handleComment}
-        onInput={checkIfVerseChanged}
+        onInput={checkIfCommentChanged}
       />
     </FormGroup>
   </div>
@@ -33,7 +33,7 @@ CommentArea.propTypes = {
   translate: PropTypes.func.isRequired,
   comment: PropTypes.string.isRequired,
   handleComment: PropTypes.func.isRequired,
-  checkIfVerseChanged: PropTypes.func.isRequired,
+  checkIfCommentChanged: PropTypes.func.isRequired,
 };
 
 export default CommentArea;

--- a/src/VerseCheck/CommentArea/index.js
+++ b/src/VerseCheck/CommentArea/index.js
@@ -9,7 +9,7 @@ const CommentArea = ({
   comment,
   translate,
   handleComment,
-  hasCommentChanged,
+  checkIfVerseChanged,
 }) => (
   <div className='comment-area'>
     <div style={{ fontWeight: 'bold' }}>
@@ -23,7 +23,7 @@ const CommentArea = ({
         defaultValue={comment}
         style={{ flex: 'auto' }}
         onBlur={handleComment}
-        onInput={hasCommentChanged}
+        onInput={checkIfVerseChanged}
       />
     </FormGroup>
   </div>
@@ -33,7 +33,7 @@ CommentArea.propTypes = {
   translate: PropTypes.func.isRequired,
   comment: PropTypes.string.isRequired,
   handleComment: PropTypes.func.isRequired,
-  hasCommentChanged: PropTypes.func.isRequired,
+  checkIfVerseChanged: PropTypes.func.isRequired,
 };
 
 export default CommentArea;

--- a/src/VerseCheck/CommentArea/index.js
+++ b/src/VerseCheck/CommentArea/index.js
@@ -6,9 +6,10 @@ import {
 import './CommentArea.styles.css';
 
 const CommentArea = ({
-  actions,
   comment,
   translate,
+  handleComment,
+  handleCheckComment,
 }) => (
   <div className='comment-area'>
     <div style={{ fontWeight: 'bold' }}>
@@ -21,8 +22,8 @@ const CommentArea = ({
         type='text'
         defaultValue={comment}
         style={{ flex: 'auto' }}
-        onBlur={actions.handleComment.bind(this)}
-        onInput={actions.checkComment.bind(this)}
+        onBlur={handleComment}
+        onInput={handleCheckComment}
       />
     </FormGroup>
   </div>
@@ -30,11 +31,9 @@ const CommentArea = ({
 
 CommentArea.propTypes = {
   translate: PropTypes.func.isRequired,
-  actions: PropTypes.shape({
-    handleComment: PropTypes.func,
-    checkComment: PropTypes.func,
-  }).isRequired,
   comment: PropTypes.string.isRequired,
+  handleComment: PropTypes.func.isRequired,
+  handleCheckComment: PropTypes.func.isRequired,
 };
 
 export default CommentArea;

--- a/src/VerseCheck/DefaultArea/index.js
+++ b/src/VerseCheck/DefaultArea/index.js
@@ -63,7 +63,7 @@ class DefaultArea extends React.Component {
       reference,
       verseText,
       selections,
-      bibles,
+      targetBible,
       bookDetails,
       targetLanguageDetails,
     } = this.props;
@@ -92,7 +92,7 @@ class DefaultArea extends React.Component {
             translate={translate}
             targetLanguageDetails={targetLanguageDetails}
             show={this.state.modalVisibility}
-            targetLangBible={bibles.targetLanguage.targetBible}
+            targetBible={targetBible}
             chapter={reference.chapter}
             currentVerse={reference.verse}
             languageDirection={languageDirection || 'ltr'}
@@ -111,7 +111,7 @@ class DefaultArea extends React.Component {
 DefaultArea.propTypes = {
   translate: PropTypes.func.isRequired,
   reference: PropTypes.object.isRequired,
-  bibles: PropTypes.object.isRequired,
+  targetBible: PropTypes.object.isRequired,
   selections: PropTypes.array.isRequired,
   verseText: PropTypes.string.isRequired,
   validateSelections: PropTypes.func.isRequired,

--- a/src/VerseCheck/DefaultArea/index.js
+++ b/src/VerseCheck/DefaultArea/index.js
@@ -19,6 +19,7 @@ class DefaultArea extends React.Component {
   }
 
   displayText(verseText, selections) {
+    const { validateSelections } = this.props;
     // normalize whitespace for text rendering in order to display highlights with more than one space since html selections show one space
     verseText = normalizeString(verseText);
     let verseTextSpans = <span>{verseText}</span>;
@@ -31,7 +32,7 @@ class DefaultArea extends React.Component {
 
         if (occurrencesInString(verseText, selection.text) !== selection.occurrences) {
           // validate selections and remove ones that do not apply
-          this.props.actions.validateSelections(verseText);
+          validateSelections(verseText);
         }
       }
 
@@ -58,18 +59,18 @@ class DefaultArea extends React.Component {
 
   render() {
     const {
-      manifest,
       translate,
       reference,
       verseText,
       selections,
       bibles,
+      bookDetails,
+      targetLanguageDetails,
     } = this.props;
-    const { target_language, project } = manifest;
-    const bookName = target_language && target_language.book && target_language.book.name ?
-      target_language.book.name : project.name;
-    const languageName = manifest.target_language ? manifest.target_language.name : null;
-    const dir = manifest.target_language ? manifest.target_language.direction : null;
+    const { book, direction } = targetLanguageDetails;
+    const bookName = book && book.name ? book.name : bookDetails.name;
+    const languageName = targetLanguageDetails.name || null;
+    const languageDirection = direction || null;
 
     return (
       <div style={{
@@ -84,23 +85,22 @@ class DefaultArea extends React.Component {
               {bookName} {reference.chapter + ':' + reference.verse}
             </span>
           </div>
-          <div onClick={() => {
-            this.setState({ modalVisibility: true });
-          }}>
+          <div onClick={() => this.setState({ modalVisibility: true })}>
             <Glyphicon glyph="fullscreen" title={translate('click_show_expanded')} style={{ cursor: 'pointer' }} />
           </div>
           <MyLanguageModal
             translate={translate}
-            manifest={manifest}
+            targetLanguageDetails={targetLanguageDetails}
             show={this.state.modalVisibility}
             targetLangBible={bibles.targetLanguage.targetBible}
             chapter={reference.chapter}
             currentVerse={reference.verse}
-            dir={dir ? dir : 'ltr'}
+            languageDirection={languageDirection || 'ltr'}
+            bookName={bookName}
             onHide={() => this.setState({ modalVisibility: false })}
           />
         </div>
-        <div className={manifest.target_language.direction === 'ltr' ? 'ltr-content' : 'rtl-content'}>
+        <div className={languageDirection === 'ltr' ? 'ltr-content' : 'rtl-content'}>
           {this.displayText(verseText, selections)}
         </div>
       </div>
@@ -110,12 +110,13 @@ class DefaultArea extends React.Component {
 
 DefaultArea.propTypes = {
   translate: PropTypes.func.isRequired,
-  actions: PropTypes.shape({ validateSelections: PropTypes.func }).isRequired,
-  reference: PropTypes.object,
+  reference: PropTypes.object.isRequired,
   bibles: PropTypes.object.isRequired,
-  manifest: PropTypes.object,
-  selections: PropTypes.array,
+  selections: PropTypes.array.isRequired,
   verseText: PropTypes.string.isRequired,
+  validateSelections: PropTypes.func.isRequired,
+  bookDetails: PropTypes.object.isRequired,
+  targetLanguageDetails: PropTypes.object.isRequired,
 };
 
 export default DefaultArea;

--- a/src/VerseCheck/EditVerseArea/index.js
+++ b/src/VerseCheck/EditVerseArea/index.js
@@ -29,7 +29,7 @@ const EditVerseArea = ({
   classes,
   handleTagsCheckbox,
   handleEditVerse,
-  handleCheckVerse,
+  hasVerseChanged,
 }) => {
   const tagList1 = [
     ['spelling', translate('spelling')],
@@ -109,7 +109,7 @@ const EditVerseArea = ({
             direction: languageDirection,
           }}
           onBlur={handleEditVerse}
-          onInput={handleCheckVerse}
+          onInput={hasVerseChanged}
         />
         <div style={{
           flex: '0 0 65px', marginTop: '5px', fontSize: '0.9em',
@@ -143,7 +143,7 @@ EditVerseArea.propTypes = {
   classes: PropTypes.object.isRequired,
   handleTagsCheckbox: PropTypes.func.isRequired,
   handleEditVerse: PropTypes.func.isRequired,
-  handleCheckVerse: PropTypes.func.isRequired,
+  hasVerseChanged: PropTypes.func.isRequired,
 };
 
 export default withStyles(styles)(EditVerseArea);

--- a/src/VerseCheck/EditVerseArea/index.js
+++ b/src/VerseCheck/EditVerseArea/index.js
@@ -21,13 +21,15 @@ const styles = {
 };
 
 const EditVerseArea = ({
-  actions,
   tags,
   verseChanged,
   verseText,
-  dir,
+  languageDirection,
   translate,
   classes,
+  handleTagsCheckbox,
+  handleEditVerse,
+  handleCheckVerse,
 }) => {
   const tagList1 = [
     ['spelling', translate('spelling')],
@@ -56,7 +58,7 @@ const EditVerseArea = ({
             checked:classes.checked,
           }}
           checked={tags.includes(tag[0])}
-          onChange={actions.handleTagsCheckbox.bind(this, tag[0])}
+          onChange={() => handleTagsCheckbox(tag[0])}
         />
       }
       label={tag[1]}
@@ -78,14 +80,14 @@ const EditVerseArea = ({
             checked:classes.checked,
           }}
           checked={tags.includes(tag[0])}
-          onChange={actions.handleTagsCheckbox.bind(this, tag[0])}
+          onChange={() => handleTagsCheckbox(tag[0])}
         />
       }
       label={tag[1]}
     />
   );
 
-  let checkBoxText = verseChanged ? translate('next_change_reason') : translate('first_make_change');
+  const checkBoxText = verseChanged ? translate('next_change_reason') : translate('first_make_change');
 
   return (
     <div className='edit-area'>
@@ -103,11 +105,11 @@ const EditVerseArea = ({
           defaultValue={verseText}
           style={{
             flex: 'auto',
-            direction: dir,
             minHeight: '110px',
+            direction: languageDirection,
           }}
-          onBlur={actions.handleEditVerse.bind(this)}
-          onInput={actions.checkVerse.bind(this)}
+          onBlur={handleEditVerse}
+          onInput={handleCheckVerse}
         />
         <div style={{
           flex: '0 0 65px', marginTop: '5px', fontSize: '0.9em',
@@ -134,16 +136,14 @@ const EditVerseArea = ({
 
 EditVerseArea.propTypes = {
   translate: PropTypes.func.isRequired,
-  actions: PropTypes.shape({
-    handleTagsCheckbox: PropTypes.func,
-    handleEditVerse: PropTypes.func,
-    checkVerse: PropTypes.func,
-  }).isRequired,
   tags: PropTypes.array.isRequired,
   verseChanged: PropTypes.bool.isRequired,
   verseText: PropTypes.string.isRequired,
-  dir: PropTypes.string.isRequired,
+  languageDirection: PropTypes.string.isRequired,
   classes: PropTypes.object.isRequired,
+  handleTagsCheckbox: PropTypes.func.isRequired,
+  handleEditVerse: PropTypes.func.isRequired,
+  handleCheckVerse: PropTypes.func.isRequired,
 };
 
 export default withStyles(styles)(EditVerseArea);

--- a/src/VerseCheck/EditVerseArea/index.js
+++ b/src/VerseCheck/EditVerseArea/index.js
@@ -22,14 +22,14 @@ const styles = {
 
 const EditVerseArea = ({
   tags,
-  verseChanged,
+  isVerseChanged,
   verseText,
   languageDirection,
   translate,
   classes,
   handleTagsCheckbox,
   handleEditVerse,
-  hasVerseChanged,
+  checkIfVerseChanged,
 }) => {
   const tagList1 = [
     ['spelling', translate('spelling')],
@@ -46,7 +46,7 @@ const EditVerseArea = ({
   const checkboxesColumn1 = tagList1.map(tag =>
     <FormControlLabel
       key={tag[0]}
-      disabled={!verseChanged}
+      disabled={!isVerseChanged}
       classes={{
         root: classes.formControlLabelRoot,
         label: classes.formControlLabel,
@@ -68,7 +68,7 @@ const EditVerseArea = ({
   const checkboxesColumn2 = tagList2.map(tag =>
     <FormControlLabel
       key={tag[0]}
-      disabled={!verseChanged}
+      disabled={!isVerseChanged}
       classes={{
         root: classes.formControlLabelRoot,
         label: classes.formControlLabel,
@@ -87,7 +87,7 @@ const EditVerseArea = ({
     />
   );
 
-  const checkBoxText = verseChanged ? translate('next_change_reason') : translate('first_make_change');
+  const checkBoxText = isVerseChanged ? translate('next_change_reason') : translate('first_make_change');
 
   return (
     <div className='edit-area'>
@@ -109,7 +109,7 @@ const EditVerseArea = ({
             direction: languageDirection,
           }}
           onBlur={handleEditVerse}
-          onInput={hasVerseChanged}
+          onInput={checkIfVerseChanged}
         />
         <div style={{
           flex: '0 0 65px', marginTop: '5px', fontSize: '0.9em',
@@ -137,13 +137,13 @@ const EditVerseArea = ({
 EditVerseArea.propTypes = {
   translate: PropTypes.func.isRequired,
   tags: PropTypes.array.isRequired,
-  verseChanged: PropTypes.bool.isRequired,
+  isVerseChanged: PropTypes.bool.isRequired,
   verseText: PropTypes.string.isRequired,
   languageDirection: PropTypes.string.isRequired,
   classes: PropTypes.object.isRequired,
   handleTagsCheckbox: PropTypes.func.isRequired,
   handleEditVerse: PropTypes.func.isRequired,
-  hasVerseChanged: PropTypes.func.isRequired,
+  checkIfVerseChanged: PropTypes.func.isRequired,
 };
 
 export default withStyles(styles)(EditVerseArea);

--- a/src/VerseCheck/IconIndicators/index.js
+++ b/src/VerseCheck/IconIndicators/index.js
@@ -4,7 +4,7 @@ import { Glyphicon } from 'react-bootstrap';
 import InvalidatedIcon from './svgIcons/InvalidatedIcon';
 
 const IconIndicators = ({
-  verseEdited,
+  isVerseEdited,
   selections,
   bookmarkEnabled,
   translate,
@@ -55,9 +55,9 @@ const IconIndicators = ({
         style={{
           margin: '0px 20px',
           color: 'var(--reverse-color)',
-          opacity: verseEdited ? 1 : 0.2,
+          opacity: isVerseEdited ? 1 : 0.2,
         }}
-        title={verseEdited ? translate('icons.verse_edits_found') : translate('icons.no_verse_edits_found')}
+        title={isVerseEdited ? translate('icons.verse_edits_found') : translate('icons.no_verse_edits_found')}
       />
       <Glyphicon
         glyph="comment"
@@ -84,7 +84,7 @@ const IconIndicators = ({
 IconIndicators.propTypes = {
   translate: PropTypes.func.isRequired,
   invalidated: PropTypes.bool.isRequired,
-  verseEdited: PropTypes.bool.isRequired,
+  isVerseEdited: PropTypes.bool.isRequired,
   selections: PropTypes.array,
   comment: PropTypes.string,
   bookmarkEnabled: PropTypes.bool,

--- a/src/VerseCheck/InstructionsArea/index.js
+++ b/src/VerseCheck/InstructionsArea/index.js
@@ -28,7 +28,7 @@ function getSelectionString(invalidated, translate) {
   }
 }
 
-let InstructionsArea = ({
+const InstructionsArea = ({
   alignedGLText,
   selections,
   dontShowTranslation,

--- a/src/VerseCheck/MyLanguageModal/index.js
+++ b/src/VerseCheck/MyLanguageModal/index.js
@@ -44,7 +44,7 @@ class MyLanguageModal extends Component {
     let {
       show,
       onHide,
-      targetLangBible,
+      targetBible,
       chapter,
       currentVerse,
       translate,
@@ -56,9 +56,9 @@ class MyLanguageModal extends Component {
     let MyTargetLanguage = [];
 
     if (show) {
-      for (let key in targetLangBible[chapter]) {
-        if (targetLangBible[chapter].hasOwnProperty(key)) {
-          let verseText = targetLangBible[chapter][key];
+      for (let key in targetBible[chapter]) {
+        if (targetBible[chapter].hasOwnProperty(key)) {
+          let verseText = targetBible[chapter][key];
           let versePaneStyle = {};
 
           if (key == currentVerse) {
@@ -139,9 +139,9 @@ class MyLanguageModal extends Component {
 MyLanguageModal.propTypes = {
   show: PropTypes.bool.isRequired,
   onHide: PropTypes.func.isRequired,
-  targetLangBible: PropTypes.object,
-  chapter: PropTypes.number,
-  currentVerse: PropTypes.number,
+  targetBible: PropTypes.object.isRequired,
+  chapter: PropTypes.number.isRequired,
+  currentVerse: PropTypes.number.isRequired,
   languageDirection: PropTypes.string.isRequired,
   translate: PropTypes.func.isRequired,
   classes: PropTypes.object.isRequired,

--- a/src/VerseCheck/MyLanguageModal/index.js
+++ b/src/VerseCheck/MyLanguageModal/index.js
@@ -42,12 +42,17 @@ class MyLanguageModal extends Component {
 
   render() {
     let {
-      show, onHide, targetLangBible, chapter, currentVerse, manifest, translate, classes,
+      show,
+      onHide,
+      targetLangBible,
+      chapter,
+      currentVerse,
+      translate,
+      classes,
+      bookName,
+      languageDirection,
     } = this.props;
-    const { target_language, project } = manifest;
-    const title = target_language && target_language.book && target_language.book.name ?
-      target_language.book.name :
-      project.name;
+    const title = bookName;
     let MyTargetLanguage = [];
 
     if (show) {
@@ -82,7 +87,7 @@ class MyLanguageModal extends Component {
                 verse={parseInt(key, 10)}
                 verseText={verseText}
                 styles={versePaneStyle}
-                dir={this.props.dir}
+                dir={languageDirection}
               />
             </div>
           );
@@ -137,10 +142,10 @@ MyLanguageModal.propTypes = {
   targetLangBible: PropTypes.object,
   chapter: PropTypes.number,
   currentVerse: PropTypes.number,
-  manifest: PropTypes.object,
-  dir: PropTypes.string.isRequired,
+  languageDirection: PropTypes.string.isRequired,
   translate: PropTypes.func.isRequired,
   classes: PropTypes.object.isRequired,
+  bookName: PropTypes.string.isRequired,
 };
 
 export default withStyles(styles)(MyLanguageModal);

--- a/src/VerseCheck/RenderSelectionTextComponent/index.js
+++ b/src/VerseCheck/RenderSelectionTextComponent/index.js
@@ -26,23 +26,31 @@ class RenderSelectionTextComponent extends Component {
 
   addSelection(selection) {
     let {
-      selections, verseText, translate,
+      selections,
+      verseText,
+      translate,
+      openAlertDialog,
+      changeSelectionsInLocalState,
     } = this.props;
     selections = selectionHelpers.addSelectionToSelections(selection, selections, verseText);
 
     // this is a good place to preview selections before saved in state
     if (selections.length <= this.props.maximumSelections) {
-      this.props.actions.changeSelectionsInLocalState(selections);
+      changeSelectionsInLocalState(selections);
     } else {
       const message = translate('select_too_many', { maximum: this.props.maximumSelections });
-      this.props.actions.openAlertDialog(message);
+      openAlertDialog(message);
     }
   }
 
   removeSelection(selection) {
-    let { selections, verseText } = this.props;
-    selections = selectionHelpers.removeSelectionFromSelections(selection, selections, verseText);
-    this.props.actions.changeSelectionsInLocalState(selections);
+    const {
+      selections,
+      verseText,
+      changeSelectionsInLocalState,
+    } = this.props;
+    const newSelections = selectionHelpers.removeSelectionFromSelections(selection, selections, verseText);
+    changeSelectionsInLocalState(newSelections);
   }
 
   inDisplayBox(insideDisplayBox) {
@@ -107,15 +115,13 @@ class RenderSelectionTextComponent extends Component {
 }
 
 RenderSelectionTextComponent.propTypes = {
-  actions: PropTypes.shape({
-    changeSelectionsInLocalState: PropTypes.func,
-    openAlertDialog: PropTypes.func,
-  }).isRequired,
   mode: PropTypes.string.isRequired,
   verseText: PropTypes.string.isRequired,
   selections: PropTypes.array.isRequired,
   translate: PropTypes.func.isRequired,
   maximumSelections: PropTypes.number.isRequired,
+  changeSelectionsInLocalState: PropTypes.func.isRequired,
+  openAlertDialog: PropTypes.func.isRequired,
 };
 
 export default RenderSelectionTextComponent;

--- a/src/VerseCheck/SaveArea/index.js
+++ b/src/VerseCheck/SaveArea/index.js
@@ -12,12 +12,6 @@ const SaveArea = ({
   handleGoToPrevious,
   handleOpenDialog,
 }) => {
-  console.log(
-    handleGoToNext,
-    handleGoToPrevious,
-    handleOpenDialog
-  );
-
   const handleNext = () => {
     selections.length > 0 || nothingToSelect ? handleGoToNext() : handleOpenDialog('next');
   };

--- a/src/VerseCheck/SaveArea/index.js
+++ b/src/VerseCheck/SaveArea/index.js
@@ -12,6 +12,12 @@ const SaveArea = ({
   handleGoToPrevious,
   handleOpenDialog,
 }) => {
+  console.log(
+    handleGoToNext,
+    handleGoToPrevious,
+    handleOpenDialog
+  );
+
   const handleNext = () => {
     selections.length > 0 || nothingToSelect ? handleGoToNext() : handleOpenDialog('next');
   };

--- a/src/VerseCheck/SaveArea/index.js
+++ b/src/VerseCheck/SaveArea/index.js
@@ -4,18 +4,20 @@ import PropTypes from 'prop-types';
 import { Glyphicon } from 'react-bootstrap';
 import './SaveArea.styles.css';
 
-let SaveArea = ({
-  actions,
+const SaveArea = ({
+  translate,
   selections,
   nothingToSelect,
-  translate,
+  handleGoToNext,
+  handleGoToPrevious,
+  handleOpenDialog,
 }) => {
   const handleNext = () => {
-    selections.length > 0 || nothingToSelect ? actions.handleGoToNext() : actions.handleOpenDialog('next');
+    selections.length > 0 || nothingToSelect ? handleGoToNext() : handleOpenDialog('next');
   };
 
   const handlePrevious = () => {
-    selections.length > 0 || nothingToSelect ? actions.handleGoToPrevious() : actions.handleOpenDialog('previous');
+    selections.length > 0 || nothingToSelect ? handleGoToPrevious() : handleOpenDialog('previous');
   };
 
   return (
@@ -38,17 +40,11 @@ let SaveArea = ({
 
 SaveArea.propTypes = {
   translate: PropTypes.func.isRequired,
-  actions: PropTypes.shape({
-    handleGoToNext: PropTypes.func,
-    handleGoToPrevious: PropTypes.func,
-    handleOpenDialog: PropTypes.func,
-  }).isRequired,
-  selections: PropTypes.array,
-  nothingToSelect: PropTypes.bool,
-  goToNextOrPrevious: PropTypes.string,
-  skipToPrevious: PropTypes.func,
-  skipToNext: PropTypes.func,
-  handleClose: PropTypes.func,
+  selections: PropTypes.array.isRequired,
+  nothingToSelect: PropTypes.bool.isRequired,
+  handleGoToNext: PropTypes.func.isRequired,
+  handleGoToPrevious: PropTypes.func.isRequired,
+  handleOpenDialog: PropTypes.func.isRequired,
 };
 
 export default SaveArea;

--- a/src/VerseCheck/SelectionArea/index.js
+++ b/src/VerseCheck/SelectionArea/index.js
@@ -1,69 +1,66 @@
-import React, { Component } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import '../VerseCheck.styles.css';
 // components
 import RenderSelectionTextComponent from '../RenderSelectionTextComponent';
 
-class SelectionArea extends Component {
-  constructor() {
-    super();
-    this.state = {
-      inBox: false,
-      modalVisibility: false,
-    };
-  }
+const SelectionArea = ({
+  translate,
+  mode,
+  reference,
+  verseText,
+  selections,
+  maximumSelections,
+  openAlertDialog,
+  changeSelectionsInLocalState,
+  bookDetails,
+  targetLanguageDetails,
+}) => {
+  const { book, direction: languageDirection } = targetLanguageDetails;
+  const bookName = book && book.name ? book.name : bookDetails.name;
+  const languageName = targetLanguageDetails.name || null;
 
-  render() {
-    const {
-      manifest, reference, translate, maximumSelections,
-    } = this.props;
-    const { target_language, project } = manifest;
-    const bookName = target_language && target_language.book && target_language.book.name ?
-      target_language.book.name : project.name;
-    const languageName = manifest.target_language ? manifest.target_language.name : null;
-    return (
-      <div style={{
-        flex: 1, display: 'flex', flexDirection: 'column',
-      }}>
-        <div className='verse-title'>
-          <div className='pane' style={{ display: 'flex', flexDirection: 'column' }}>
-            <span className='verse-title-title'>
-              {languageName}
-            </span>
-            <span className='verse-title-subtitle'>
-              {bookName} {reference.chapter + ':' + reference.verse}
-            </span>
-          </div>
-        </div>
-        <div style={{ overflow: 'auto' }}>
-          <div className={manifest.target_language.direction === 'ltr' ? 'ltr-content' : 'rtl-content'}>
-            <RenderSelectionTextComponent
-              translate={translate}
-              actions={this.props.actions}
-              mode={this.props.mode}
-              verseText={this.props.verseText}
-              selections={this.props.selections}
-              maximumSelections={maximumSelections}
-            />
-          </div>
+  return (
+    <div className='selection-area-root'>
+      <div className='verse-title'>
+        <div className='pane' style={{ display: 'flex', flexDirection: 'column' }}>
+          <span className='verse-title-title'>
+            {languageName}
+          </span>
+          <span className='verse-title-subtitle'>
+            {bookName} {reference.chapter + ':' + reference.verse}
+          </span>
         </div>
       </div>
-    );
-  }
-}
+      <div style={{ overflow: 'auto' }}>
+        <div className={languageDirection === 'ltr' ? 'ltr-content' : 'rtl-content'}>
+          <RenderSelectionTextComponent
+            translate={translate}
+            mode={mode}
+            verseText={verseText}
+            selections={selections}
+            maximumSelections={maximumSelections}
+            openAlertDialog={openAlertDialog}
+            changeSelectionsInLocalState={changeSelectionsInLocalState}
+          />
+        </div>
+      </div>
+    </div>
+  );
+};
+
 
 SelectionArea.propTypes = {
-  actions: PropTypes.shape({
-    changeSelectionsInLocalState: PropTypes.func,
-    openAlertDialog: PropTypes.func,
-  }).isRequired,
-  manifest: PropTypes.object,
-  reference: PropTypes.object,
+  reference: PropTypes.object.isRequired,
   mode: PropTypes.string.isRequired,
   verseText: PropTypes.string.isRequired,
   selections: PropTypes.array.isRequired,
   translate: PropTypes.func.isRequired,
   maximumSelections: PropTypes.number.isRequired,
+  changeSelectionsInLocalState: PropTypes.func.isRequired,
+  openAlertDialog: PropTypes.func.isRequired,
+  bookDetails: PropTypes.object.isRequired,
+  targetLanguageDetails: PropTypes.object.isRequired,
 };
 
 export default SelectionArea;

--- a/src/VerseCheck/VerseCheck.js
+++ b/src/VerseCheck/VerseCheck.js
@@ -219,6 +219,7 @@ VerseCheck.defaultProps = {
   translate: key => key,
   verseText: '',
   unfilteredVerseText: '',
+  commentText: '',
 };
 
 export default VerseCheck;

--- a/src/VerseCheck/VerseCheck.js
+++ b/src/VerseCheck/VerseCheck.js
@@ -31,7 +31,7 @@ class VerseCheck extends Component {
       selections,
       newSelections,
       nothingToSelect,
-      verseEdited,
+      isVerseEdited,
       commentText,
       bookmarkEnabled,
       isVerseInvalidated,
@@ -96,7 +96,7 @@ class VerseCheck extends Component {
             <div className='title-bar'>
               <span>{titleText}</span>
               <IconIndicators
-                verseEdited={verseEdited}
+                isVerseEdited={isVerseEdited}
                 selections={selections}
                 comment={commentText}
                 bookmarkEnabled={bookmarkEnabled}
@@ -174,7 +174,7 @@ VerseCheck.propTypes = {
   selections: PropTypes.array.isRequired,
   newSelections: PropTypes.array.isRequired,
   nothingToSelect: PropTypes.bool.isRequired,
-  verseEdited: PropTypes.bool.isRequired,
+  isVerseEdited: PropTypes.bool.isRequired,
   commentText: PropTypes.string.isRequired,
   bookmarkEnabled: PropTypes.bool.isRequired,
   isVerseInvalidated: PropTypes.bool.isRequired,

--- a/src/VerseCheck/VerseCheck.js
+++ b/src/VerseCheck/VerseCheck.js
@@ -36,7 +36,7 @@ class VerseCheck extends Component {
       bookmarkEnabled,
       isVerseInvalidated,
       contextId,
-      bibles,
+      targetBible,
       handleCloseDialog,
       handleGoToNext,
       handleGoToPrevious,
@@ -119,7 +119,7 @@ class VerseCheck extends Component {
               targetLanguageDetails={targetLanguageDetails}
               bookDetails={bookDetails}
               contextId={contextId}
-              bibles={bibles}// TODO:
+              targetBible={targetBible}// TODO:
               alignedGLText={alignedGLText}
               invalidated={isVerseInvalidated}
               maximumSelections={maximumSelections}
@@ -179,7 +179,7 @@ VerseCheck.propTypes = {
   bookmarkEnabled: PropTypes.bool.isRequired,
   isVerseInvalidated: PropTypes.bool.isRequired,
   contextId: PropTypes.object.isRequired,
-  bibles: PropTypes.object.isRequired,
+  targetBible: PropTypes.object.isRequired,
   bookDetails: PropTypes.object.isRequired,
   targetLanguageDetails: PropTypes.object.isRequired,
   alignedGLText: PropTypes.string.isRequired,
@@ -215,6 +215,10 @@ VerseCheck.propTypes = {
   changeSelectionsInLocalState: PropTypes.func.isRequired,
 };
 
-VerseCheck.defaultProps = { translate: key => key };
+VerseCheck.defaultProps = {
+  translate: key => key,
+  verseText: '',
+  unfilteredVerseText: '',
+};
 
 export default VerseCheck;

--- a/src/VerseCheck/VerseCheck.js
+++ b/src/VerseCheck/VerseCheck.js
@@ -54,7 +54,7 @@ class VerseCheck extends Component {
       targetLanguageDetails,
       handleTagsCheckbox,
       handleEditVerse,
-      handleCheckVerse,
+      hasVerseChanged,
       hasCommentChanged,
       validateSelections,
     } = this.props;
@@ -126,7 +126,7 @@ class VerseCheck extends Component {
               handleComment={handleComment}
               openAlertDialog={openAlertDialog}
               handleEditVerse={handleEditVerse}
-              handleCheckVerse={handleCheckVerse}
+              hasVerseChanged={hasVerseChanged}
               hasCommentChanged={hasCommentChanged}
               handleTagsCheckbox={handleTagsCheckbox}
               validateSelections={validateSelections}
@@ -208,7 +208,7 @@ VerseCheck.propTypes = {
   clearSelection: PropTypes.func.isRequired,
   handleSkip: PropTypes.func.isRequired,
   handleEditVerse: PropTypes.func.isRequired,
-  handleCheckVerse: PropTypes.func.isRequired,
+  hasVerseChanged: PropTypes.func.isRequired,
   hasCommentChanged: PropTypes.func.isRequired,
   validateSelections: PropTypes.func.isRequired,
   handleTagsCheckbox: PropTypes.func.isRequired,

--- a/src/VerseCheck/VerseCheck.js
+++ b/src/VerseCheck/VerseCheck.js
@@ -1,6 +1,4 @@
-/**
- * component displays the Verse so selection, edit and comments can be made.
- */
+/* eslint-disable indent */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import ActionsArea from './ActionsArea';
@@ -15,24 +13,14 @@ class VerseCheck extends Component {
   render() {
     const {
       translate,
-      commentsReducer,
-      remindersReducer,
-      projectDetailsReducer,
-      contextIdReducer,
-      resourcesReducer,
-      selectionsReducer,
       alignedGLText,
       verseText,
       unfilteredVerseText,
       mode,
-      actions,
       dialogModalVisibility,
       commentChanged,
-      findIfVerseEdited,
-      findIfVerseInvalidated,
       tags,
       verseChanged,
-      selections,
       saveSelection,
       cancelSelection,
       clearSelection,
@@ -40,171 +28,193 @@ class VerseCheck extends Component {
       toggleNothingToSelect,
       localNothingToSelect,
       maximumSelections,
+      selections,
+      newSelections,
+      nothingToSelect,
+      verseEdited,
+      commentText,
+      bookmarkEnabled,
+      isVerseInvalidated,
+      contextId,
+      bibles,
+      handleCloseDialog,
+      handleGoToNext,
+      handleGoToPrevious,
+      handleOpenDialog,
+      openAlertDialog,
+      changeSelectionsInLocalState,
+      toggleReminder,
+      changeMode,
+      cancelEditVerse,
+      saveEditVerse,
+      handleComment,
+      cancelComment,
+      saveComment,
+      bookDetails,
+      targetLanguageDetails,
+      handleTagsCheckbox,
+      handleEditVerse,
+      handleCheckVerse,
+      handleCheckComment,
+      validateSelections,
     } = this.props;
 
     let titleText;
     let saveArea;
 
     switch (mode) {
-    case 'edit':
-      titleText = translate('edit_verse');
-      saveArea = <div />;
-      break;
-    case 'comment':
-      titleText = translate('comment');
-      saveArea = <div />;
-      break;
-    case 'select':
-      titleText = translate('select');
-      saveArea = <div />;
-      break;
-    default:
-      titleText = translate('step2_check');
-      saveArea = (
-        <SaveArea
-          actions={actions}
-          selections={selectionsReducer.selections}
-          nothingToSelect={!!selectionsReducer.nothingToSelect}
-          translate={translate} />);
+      case 'edit':
+        titleText = translate('edit_verse');
+        saveArea = <div />;
+        break;
+      case 'comment':
+        titleText = translate('comment');
+        saveArea = <div />;
+        break;
+      case 'select':
+        titleText = translate('select');
+        saveArea = <div />;
+        break;
+      default:
+        titleText = translate('step2_check');
+        saveArea = (
+          <SaveArea
+            translate={translate}
+            selections={selections}
+            nothingToSelect={nothingToSelect}
+            handleGoToNext={handleGoToNext}
+            handleGoToPrevious={handleGoToPrevious}
+            handleOpenDialog={handleOpenDialog}
+          />
+        );
     }
 
     return (
       <div className='verse-check'>
-        <div style={{
-          display: 'flex', flexDirection: 'column', height: '100%', width:'100%',
-        }}>
+        <div className='verse-check-flex'>
           <div className='verse-check-card'>
             <div className='title-bar'>
               <span>{titleText}</span>
               <IconIndicators
-                verseEdited={findIfVerseEdited()}
-                selections={selectionsReducer.selections}
-                comment={commentsReducer.text}
-                bookmarkEnabled={remindersReducer.enabled}
+                verseEdited={verseEdited}
+                selections={selections}
+                comment={commentText}
+                bookmarkEnabled={bookmarkEnabled}
                 translate={translate}
-                nothingToSelect={!!selectionsReducer.nothingToSelect}
-                invalidated={findIfVerseInvalidated()} />
+                nothingToSelect={nothingToSelect}
+                invalidated={isVerseInvalidated}
+              />
             </div>
             <CheckArea
-              actions={actions}
               mode={mode}
               tags={tags}
               verseText={verseText}
               unfilteredVerseText={unfilteredVerseText}
               verseChanged={verseChanged}
-              comment={commentsReducer.text}
-              newSelections={selections}
-              selections={selectionsReducer.selections}
+              comment={commentText}
+              newSelections={newSelections}
+              selections={selections}
               translate={translate}
-              nothingToSelect={!!selectionsReducer.nothingToSelect}
-              projectDetailsReducer={projectDetailsReducer}
-              contextId={contextIdReducer.contextId}
-              bibles={resourcesReducer.bibles}
+              nothingToSelect={nothingToSelect}
+              targetLanguageDetails={targetLanguageDetails}
+              bookDetails={bookDetails}
+              contextId={contextId}
+              bibles={bibles}// TODO:
               alignedGLText={alignedGLText}
-              invalidated={findIfVerseInvalidated()}
-              maximumSelections={maximumSelections} />
+              invalidated={isVerseInvalidated}
+              maximumSelections={maximumSelections}
+              handleComment={handleComment}
+              openAlertDialog={openAlertDialog}
+              handleEditVerse={handleEditVerse}
+              handleCheckVerse={handleCheckVerse}
+              handleCheckComment={handleCheckComment}
+              handleTagsCheckbox={handleTagsCheckbox}
+              validateSelections={validateSelections}
+              changeSelectionsInLocalState={changeSelectionsInLocalState}
+            />
             <ActionsArea
               mode={mode}
               tags={tags}
-              actions={actions}
               toggleNothingToSelect={toggleNothingToSelect}
               localNothingToSelect={localNothingToSelect}
-              nothingToSelect={!!selectionsReducer.nothingToSelect}
+              nothingToSelect={nothingToSelect}
               commentChanged={commentChanged}
-              selections={selectionsReducer.selections}
-              newSelections={selections}
-              remindersReducer={remindersReducer}
+              selections={selections}
+              newSelections={newSelections}
+              translate={translate}
+              bookmarkEnabled={bookmarkEnabled}
               saveSelection={saveSelection}
               cancelSelection={cancelSelection}
               clearSelection={clearSelection}
-              translate={translate} />
+              toggleReminder={toggleReminder}
+              changeMode={changeMode}
+              cancelEditVerse={cancelEditVerse}
+              saveEditVerse={saveEditVerse}
+              cancelComment={cancelComment}
+              saveComment={saveComment}
+            />
           </div>
           {saveArea}
         </div>
         <DialogComponent
           handleSkip={handleSkip}
           dialogModalVisibility={dialogModalVisibility}
-          handleClose={actions.handleCloseDialog}
+          handleClose={handleCloseDialog}
           translate={translate} />
       </div>
     );
   }
 }
 
+
 VerseCheck.propTypes = {
+  translate: PropTypes.func.isRequired,
+  mode: PropTypes.string.isRequired,
+  tags: PropTypes.array.isRequired,
+  selections: PropTypes.array.isRequired,
+  newSelections: PropTypes.array.isRequired,
+  nothingToSelect: PropTypes.bool.isRequired,
+  verseEdited: PropTypes.bool.isRequired,
+  commentText: PropTypes.string.isRequired,
+  bookmarkEnabled: PropTypes.bool.isRequired,
+  isVerseInvalidated: PropTypes.bool.isRequired,
+  contextId: PropTypes.object.isRequired,
+  bibles: PropTypes.object.isRequired,
+  bookDetails: PropTypes.object.isRequired,
+  targetLanguageDetails: PropTypes.object.isRequired,
   alignedGLText: PropTypes.string.isRequired,
   commentChanged: PropTypes.bool.isRequired,
-  findIfVerseEdited: PropTypes.func.isRequired,
-  findIfVerseInvalidated: PropTypes.func.isRequired,
-  tags: PropTypes.array.isRequired,
   verseChanged: PropTypes.bool.isRequired,
-  selections: PropTypes.array.isRequired,
+  verseText: PropTypes.string.isRequired,
+  unfilteredVerseText: PropTypes.string.isRequired,
+  dialogModalVisibility: PropTypes.bool.isRequired,
+  localNothingToSelect: PropTypes.bool.isRequired,
+  maximumSelections: PropTypes.number.isRequired,
+  handleCloseDialog: PropTypes.func.isRequired,
+  handleGoToNext: PropTypes.func.isRequired,
+  handleGoToPrevious: PropTypes.func.isRequired,
+  handleOpenDialog: PropTypes.func.isRequired,
+  openAlertDialog: PropTypes.func.isRequired,
+  toggleReminder: PropTypes.func.isRequired,
+  changeMode: PropTypes.func.isRequired,
+  cancelEditVerse: PropTypes.func.isRequired,
+  saveEditVerse: PropTypes.func.isRequired,
+  handleComment: PropTypes.func.isRequired,
+  cancelComment: PropTypes.func.isRequired,
+  saveComment: PropTypes.func.isRequired,
+  toggleNothingToSelect: PropTypes.func.isRequired,
   saveSelection: PropTypes.func.isRequired,
   cancelSelection: PropTypes.func.isRequired,
   clearSelection: PropTypes.func.isRequired,
   handleSkip: PropTypes.func.isRequired,
-  verseText: PropTypes.string,
-  unfilteredVerseText: PropTypes.string,
-  remindersReducer: PropTypes.object.isRequired,
-  groupsDataReducer: PropTypes.object.isRequired,
-  toolsReducer: PropTypes.object.isRequired,
-  translate: PropTypes.func.isRequired,
-  actions: PropTypes.object.isRequired,
-  contextIdReducer: PropTypes.shape({ contextId: PropTypes.object }).isRequired,
-  selectionsReducer: PropTypes.object.isRequired,
-  commentsReducer: PropTypes.object.isRequired,
-  resourcesReducer: PropTypes.object.isRequired,
-  loginReducer: PropTypes.object.isRequired,
-  projectDetailsReducer: PropTypes.object.isRequired,
-  mode: PropTypes.string.isRequired,
-  dialogModalVisibility: PropTypes.bool.isRequired,
-  localNothingToSelect: PropTypes.bool.isRequired,
-  nothingToSelect: PropTypes.bool.isRequired,
-  toggleNothingToSelect: PropTypes.func.isRequired,
-  maximumSelections: PropTypes.number.isRequired,
+  handleEditVerse: PropTypes.func.isRequired,
+  handleCheckVerse: PropTypes.func.isRequired,
+  handleCheckComment: PropTypes.func.isRequired,
+  validateSelections: PropTypes.func.isRequired,
+  handleTagsCheckbox: PropTypes.func.isRequired,
+  changeSelectionsInLocalState: PropTypes.func.isRequired,
 };
 
-VerseCheck.defaultProps = {
-  contextIdReducer: {
-    contextId: {
-      reference: {
-        chapter: 1,
-        verse: 1,
-        bookId: 'tit',
-      },
-    },
-  },
-  projectDetailsReducer: {
-    manifest: {
-      project: { id: 'tit' },
-      target_language: { direction: 'ltr' },
-    },
-  },
-  resourcesReducer: { bibles: { targetLanguage: { targetBible: { 1: { 1: '' } } } } },
-  selectionsReducer: { selections: [] },
-  toolsReducer: { currentToolName: 'tw' },
-  translate: key => key,
-  groupsDataReducer: { groupsData: {} },
-  commentsReducer: { text: '' },
-  remindersReducer: { enabled: false },
-  loginReducer: {},
-  alignedGLText: '',
-  mode: 'default',
-  commentChanged: false,
-  findIfVerseEdited: () => false,
-  findIfVerseInvalidated: () => false,
-  tags: [],
-  verseChanged: false,
-  selections: [],
-  saveSelection: () => {},
-  cancelSelection: () => {},
-  clearSelection: () => {},
-  handleSkip: () => {},
-  verseText: '',
-  unfilteredVerseText: '',
-  dialogModalVisibility: false,
-  localNothingToSelect: false,
-  nothingToSelect: false,
-};
+VerseCheck.defaultProps = { translate: key => key };
 
 export default VerseCheck;

--- a/src/VerseCheck/VerseCheck.js
+++ b/src/VerseCheck/VerseCheck.js
@@ -18,9 +18,9 @@ class VerseCheck extends Component {
       unfilteredVerseText,
       mode,
       dialogModalVisibility,
-      commentChanged,
+      isCommentChanged,
       tags,
-      verseChanged,
+      isVerseChanged,
       saveSelection,
       cancelSelection,
       clearSelection,
@@ -54,8 +54,8 @@ class VerseCheck extends Component {
       targetLanguageDetails,
       handleTagsCheckbox,
       handleEditVerse,
-      hasVerseChanged,
-      hasCommentChanged,
+      checkIfVerseChanged,
+      checkIfCommentChanged,
       validateSelections,
     } = this.props;
 
@@ -110,7 +110,7 @@ class VerseCheck extends Component {
               tags={tags}
               verseText={verseText}
               unfilteredVerseText={unfilteredVerseText}
-              verseChanged={verseChanged}
+              isVerseChanged={isVerseChanged}
               comment={commentText}
               newSelections={newSelections}
               selections={selections}
@@ -126,8 +126,8 @@ class VerseCheck extends Component {
               handleComment={handleComment}
               openAlertDialog={openAlertDialog}
               handleEditVerse={handleEditVerse}
-              hasVerseChanged={hasVerseChanged}
-              hasCommentChanged={hasCommentChanged}
+              checkIfVerseChanged={checkIfVerseChanged}
+              checkIfCommentChanged={checkIfCommentChanged}
               handleTagsCheckbox={handleTagsCheckbox}
               validateSelections={validateSelections}
               changeSelectionsInLocalState={changeSelectionsInLocalState}
@@ -138,7 +138,7 @@ class VerseCheck extends Component {
               toggleNothingToSelect={toggleNothingToSelect}
               localNothingToSelect={localNothingToSelect}
               nothingToSelect={nothingToSelect}
-              commentChanged={commentChanged}
+              isCommentChanged={isCommentChanged}
               selections={selections}
               newSelections={newSelections}
               translate={translate}
@@ -183,8 +183,8 @@ VerseCheck.propTypes = {
   bookDetails: PropTypes.object.isRequired,
   targetLanguageDetails: PropTypes.object.isRequired,
   alignedGLText: PropTypes.string.isRequired,
-  commentChanged: PropTypes.bool.isRequired,
-  verseChanged: PropTypes.bool.isRequired,
+  isCommentChanged: PropTypes.bool.isRequired,
+  isVerseChanged: PropTypes.bool.isRequired,
   verseText: PropTypes.string.isRequired,
   unfilteredVerseText: PropTypes.string.isRequired,
   dialogModalVisibility: PropTypes.bool.isRequired,
@@ -208,8 +208,8 @@ VerseCheck.propTypes = {
   clearSelection: PropTypes.func.isRequired,
   handleSkip: PropTypes.func.isRequired,
   handleEditVerse: PropTypes.func.isRequired,
-  hasVerseChanged: PropTypes.func.isRequired,
-  hasCommentChanged: PropTypes.func.isRequired,
+  checkIfVerseChanged: PropTypes.func.isRequired,
+  checkIfCommentChanged: PropTypes.func.isRequired,
   validateSelections: PropTypes.func.isRequired,
   handleTagsCheckbox: PropTypes.func.isRequired,
   changeSelectionsInLocalState: PropTypes.func.isRequired,

--- a/src/VerseCheck/VerseCheck.js
+++ b/src/VerseCheck/VerseCheck.js
@@ -55,7 +55,7 @@ class VerseCheck extends Component {
       handleTagsCheckbox,
       handleEditVerse,
       handleCheckVerse,
-      handleCheckComment,
+      hasCommentChanged,
       validateSelections,
     } = this.props;
 
@@ -127,7 +127,7 @@ class VerseCheck extends Component {
               openAlertDialog={openAlertDialog}
               handleEditVerse={handleEditVerse}
               handleCheckVerse={handleCheckVerse}
-              handleCheckComment={handleCheckComment}
+              hasCommentChanged={hasCommentChanged}
               handleTagsCheckbox={handleTagsCheckbox}
               validateSelections={validateSelections}
               changeSelectionsInLocalState={changeSelectionsInLocalState}
@@ -209,7 +209,7 @@ VerseCheck.propTypes = {
   handleSkip: PropTypes.func.isRequired,
   handleEditVerse: PropTypes.func.isRequired,
   handleCheckVerse: PropTypes.func.isRequired,
-  handleCheckComment: PropTypes.func.isRequired,
+  hasCommentChanged: PropTypes.func.isRequired,
   validateSelections: PropTypes.func.isRequired,
   handleTagsCheckbox: PropTypes.func.isRequired,
   changeSelectionsInLocalState: PropTypes.func.isRequired,

--- a/src/VerseCheck/VerseCheck.styles.css
+++ b/src/VerseCheck/VerseCheck.styles.css
@@ -6,6 +6,14 @@
   display: flex;
   margin: 10px;
 }
+
+.verse-check-flex {
+  display:flex;
+  flex-direction:column;
+  height: 100%;
+  width:100%;
+}
+
 .verse-check .ltr-content {
   direction: ltr;
   flex: auto;
@@ -49,4 +57,10 @@
   display: flex;
   justify-content: space-between;
   margin: 5px 10px 5px 15px;
+}
+
+.selection-area-root {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
 }

--- a/src/VerseCheck/__tests__/__snapshots__/ViewCheck.test.js.snap
+++ b/src/VerseCheck/__tests__/__snapshots__/ViewCheck.test.js.snap
@@ -5,14 +5,7 @@ exports[`VerseCheck component: Integrated View test - edit mode 1`] = `
   className="verse-check"
 >
   <div
-    style={
-      Object {
-        "display": "flex",
-        "flexDirection": "column",
-        "height": "100%",
-        "width": "100%",
-      }
-    }
+    className="verse-check-flex"
   >
     <div
       className="verse-check-card"
@@ -195,8 +188,6 @@ exports[`VerseCheck component: Integrated View test - edit mode 1`] = `
 \\\\s5
 "
                 id="formControlsTextarea"
-                onBlur={[Function]}
-                onInput={[Function]}
                 style={
                   Object {
                     "direction": "ltr",
@@ -543,14 +534,12 @@ exports[`VerseCheck component: Integrated View test - edit mode 1`] = `
       >
         <button
           className="btn-second"
-          onClick={[Function]}
         >
           cancel
         </button>
         <button
           className="btn-prime"
           disabled={true}
-          onClick={[Function]}
         >
           <span
             className="glyphicon glyphicon-ok"
@@ -575,14 +564,7 @@ exports[`VerseCheck component: Integrated View test 1`] = `
   className="verse-check"
 >
   <div
-    style={
-      Object {
-        "display": "flex",
-        "flexDirection": "column",
-        "height": "100%",
-        "width": "100%",
-      }
-    }
+    className="verse-check-flex"
   >
     <div
       className="verse-check-card"
@@ -651,13 +633,7 @@ exports[`VerseCheck component: Integrated View test 1`] = `
         className="check-area"
       >
         <div
-          style={
-            Object {
-              "display": "flex",
-              "flex": 1,
-              "flexDirection": "column",
-            }
-          }
+          className="selection-area-root"
         >
           <div
             className="verse-title"
@@ -745,7 +721,7 @@ exports[`VerseCheck component: Integrated View test 1`] = `
                     }
                   }
                 >
-                  ""
+                  "undefined"
                 </strong>
               </span>
               <br />
@@ -792,7 +768,6 @@ exports[`VerseCheck component: Integrated View test 1`] = `
                   />
                 </svg>
                 <input
-                  checked={false}
                   className="MuiPrivateSwitchBase-input-21"
                   data-indeterminate={false}
                   disabled={false}
@@ -923,14 +898,7 @@ exports[`VerseCheck component: Integrated View test with default and invalidated
   className="verse-check"
 >
   <div
-    style={
-      Object {
-        "display": "flex",
-        "flexDirection": "column",
-        "height": "100%",
-        "width": "100%",
-      }
-    }
+    className="verse-check-flex"
   >
     <div
       className="verse-check-card"
@@ -949,91 +917,6 @@ exports[`VerseCheck component: Integrated View test with default and invalidated
             }
           }
         >
-          <div
-            className="glyphicon glyphicon-invalidated"
-            style={
-              Object {
-                "margin": "0px 20px",
-              }
-            }
-          >
-            <svg
-              height="16"
-              style={
-                Object {
-                  "display": "inline-block",
-                  "verticalAlign": "middle",
-                }
-              }
-              viewBox="0 0 475.082 475.082"
-              width="16"
-            >
-              <path
-                d="M107.067,317.195c1.713-1.708,2.568-3.898,2.568-6.563c0-2.663-0.855-4.853-2.568-6.571    c-1.714-1.707-3.905-2.562-6.567-2.562H9.135c-2.666,0-4.853,0.855-6.567,2.562C0.859,305.772,0,307.962,0,310.632    c0,2.665,0.855,4.855,2.568,6.563c1.714,1.711,3.905,2.566,6.567,2.566H100.5C103.166,319.766,105.353,318.91,107.067,317.195z"
-                style={
-                  Object {
-                    "fill": "#ffffff",
-                  }
-                }
-              />
-              <path
-                d="M310.629,109.634c2.669,0,4.859-0.855,6.563-2.568c1.718-1.711,2.574-3.901,2.574-6.567V9.138    c0-2.659-0.856-4.85-2.574-6.565c-1.704-1.711-3.895-2.57-6.563-2.57c-2.662,0-4.853,0.859-6.563,2.57    c-1.711,1.713-2.566,3.903-2.566,6.565v91.361c0,2.666,0.855,4.856,2.566,6.567C305.784,108.779,307.974,109.634,310.629,109.634z    "
-                style={
-                  Object {
-                    "fill": "#ffffff",
-                  }
-                }
-              />
-              <path
-                d="M118.771,347.184c-2.478,0-4.664,0.855-6.567,2.563l-73.089,73.087c-1.713,1.902-2.568,4.093-2.568,6.567    c0,2.474,0.855,4.664,2.568,6.566c2.096,1.708,4.283,2.57,6.567,2.57c2.475,0,4.665-0.862,6.567-2.57l73.089-73.087    c1.714-1.902,2.568-4.093,2.568-6.57c0-2.471-0.854-4.661-2.568-6.563C123.436,348.039,121.245,347.184,118.771,347.184z"
-                style={
-                  Object {
-                    "fill": "#ffffff",
-                  }
-                }
-              />
-              <path
-                d="M356.315,127.905c2.283,0,4.473-0.855,6.571-2.565l73.087-73.089c1.707-1.903,2.562-4.093,2.562-6.567    c0-2.475-0.855-4.665-2.562-6.567c-1.91-1.709-4.093-2.568-6.571-2.568c-2.471,0-4.66,0.859-6.563,2.568l-73.087,73.089    c-1.708,1.903-2.57,4.093-2.57,6.567c0,2.474,0.862,4.661,2.57,6.567C351.846,127.05,354.037,127.905,356.315,127.905z"
-                style={
-                  Object {
-                    "fill": "#ffffff",
-                  }
-                }
-              />
-              <path
-                d="M350.607,193.005c-4-3.999-9.328-7.994-15.988-11.991l-5.14,68.238l78.23,78.508c5.328,5.328,7.987,11.807,7.987,19.417    c0,7.423-2.662,13.802-7.987,19.13l-41.977,41.686c-5.146,5.146-11.608,7.666-19.417,7.566c-7.81-0.1-14.271-2.707-19.411-7.854    l-77.946-78.225l-68.234,5.144c3.999,6.656,7.993,11.988,11.991,15.985l95.362,95.643c15.803,16.18,35.207,24.27,58.238,24.27    c22.846,0,42.154-7.898,57.957-23.695l41.977-41.685c16.173-15.8,24.27-35.115,24.27-57.958c0-22.46-7.994-41.877-23.982-58.248    L350.607,193.005z"
-                style={
-                  Object {
-                    "fill": "#ffffff",
-                  }
-                }
-              />
-              <path
-                d="M472.518,157.889c-1.711-1.709-3.901-2.565-6.563-2.565h-91.365c-2.662,0-4.853,0.855-6.563,2.565    c-1.715,1.713-2.57,3.903-2.57,6.567c0,2.666,0.855,4.856,2.57,6.567c1.711,1.712,3.901,2.568,6.563,2.568h91.365    c2.662,0,4.853-0.856,6.563-2.568c1.708-1.711,2.563-3.901,2.563-6.567C475.082,161.792,474.226,159.602,472.518,157.889z"
-                style={
-                  Object {
-                    "fill": "#ffffff",
-                  }
-                }
-              />
-              <path
-                d="M109.348,67.099c5.523-5.14,11.991-7.705,19.417-7.705c7.611,0,14.084,2.663,19.414,7.993l77.943,78.227l68.234-5.142    c-4-6.661-7.99-11.991-11.991-15.987l-95.358-95.643c-15.798-16.178-35.212-24.27-58.242-24.27c-22.841,0-42.16,7.902-57.958,23.7    L28.837,69.955C12.659,85.756,4.57,105.073,4.57,127.912c0,22.463,7.996,41.877,23.982,58.245l95.93,95.93    c3.995,4.001,9.325,7.995,15.986,11.991l5.139-68.521L67.377,147.33c-5.327-5.33-7.992-11.801-7.992-19.417    c0-7.421,2.662-13.796,7.992-19.126L109.348,67.099z"
-                style={
-                  Object {
-                    "fill": "#ffffff",
-                  }
-                }
-              />
-              <path
-                d="M164.454,365.451c-2.667,0-4.854,0.855-6.567,2.563c-1.711,1.711-2.568,3.901-2.568,6.57v91.358    c0,2.669,0.854,4.853,2.568,6.57c1.713,1.707,3.9,2.566,6.567,2.566c2.666,0,4.853-0.859,6.567-2.566    c1.713-1.718,2.568-3.901,2.568-6.57v-91.358c0-2.662-0.855-4.853-2.568-6.57C169.306,366.307,167.116,365.451,164.454,365.451z"
-                style={
-                  Object {
-                    "fill": "#ffffff",
-                  }
-                }
-              />
-            </svg>
-          </div>
           <span
             className="glyphicon glyphicon-ok"
             style={
@@ -1174,45 +1057,8 @@ exports[`VerseCheck component: Integrated View test with default and invalidated
             <div
               className="instructions-area"
             >
-              <div>
-                <span>
-                  selection_invalidated
-                  <strong
-                    data-class="selection-tooltip"
-                    data-delay-hide="100"
-                    data-effect="float"
-                    data-place="top"
-                    data-tip="invalidated_tooltip"
-                    data-type="dark"
-                    style={
-                      Object {
-                        "fontSize": "0.8em",
-                        "verticalAlign": "super",
-                      }
-                    }
-                  >
-                    1
-                  </strong>
-                </span>
-                <div
-                  className="__react_component_tooltip place-top type-dark "
-                  data-id="tooltip"
-                />
-              </div>
               <span>
-                please_select
-              </span>
-              <br />
-              <span>
-                <strong
-                  style={
-                    Object {
-                      "color": "var(--accent-color)",
-                    }
-                  }
-                >
-                  ""
-                </strong>
+                no_selection
               </span>
               <br />
             </div>
@@ -1390,14 +1236,7 @@ exports[`VerseCheck component: Integrated View test with invalidated 1`] = `
   className="verse-check"
 >
   <div
-    style={
-      Object {
-        "display": "flex",
-        "flexDirection": "column",
-        "height": "100%",
-        "width": "100%",
-      }
-    }
+    className="verse-check-flex"
   >
     <div
       className="verse-check-card"
@@ -1416,91 +1255,6 @@ exports[`VerseCheck component: Integrated View test with invalidated 1`] = `
             }
           }
         >
-          <div
-            className="glyphicon glyphicon-invalidated"
-            style={
-              Object {
-                "margin": "0px 20px",
-              }
-            }
-          >
-            <svg
-              height="16"
-              style={
-                Object {
-                  "display": "inline-block",
-                  "verticalAlign": "middle",
-                }
-              }
-              viewBox="0 0 475.082 475.082"
-              width="16"
-            >
-              <path
-                d="M107.067,317.195c1.713-1.708,2.568-3.898,2.568-6.563c0-2.663-0.855-4.853-2.568-6.571    c-1.714-1.707-3.905-2.562-6.567-2.562H9.135c-2.666,0-4.853,0.855-6.567,2.562C0.859,305.772,0,307.962,0,310.632    c0,2.665,0.855,4.855,2.568,6.563c1.714,1.711,3.905,2.566,6.567,2.566H100.5C103.166,319.766,105.353,318.91,107.067,317.195z"
-                style={
-                  Object {
-                    "fill": "#ffffff",
-                  }
-                }
-              />
-              <path
-                d="M310.629,109.634c2.669,0,4.859-0.855,6.563-2.568c1.718-1.711,2.574-3.901,2.574-6.567V9.138    c0-2.659-0.856-4.85-2.574-6.565c-1.704-1.711-3.895-2.57-6.563-2.57c-2.662,0-4.853,0.859-6.563,2.57    c-1.711,1.713-2.566,3.903-2.566,6.565v91.361c0,2.666,0.855,4.856,2.566,6.567C305.784,108.779,307.974,109.634,310.629,109.634z    "
-                style={
-                  Object {
-                    "fill": "#ffffff",
-                  }
-                }
-              />
-              <path
-                d="M118.771,347.184c-2.478,0-4.664,0.855-6.567,2.563l-73.089,73.087c-1.713,1.902-2.568,4.093-2.568,6.567    c0,2.474,0.855,4.664,2.568,6.566c2.096,1.708,4.283,2.57,6.567,2.57c2.475,0,4.665-0.862,6.567-2.57l73.089-73.087    c1.714-1.902,2.568-4.093,2.568-6.57c0-2.471-0.854-4.661-2.568-6.563C123.436,348.039,121.245,347.184,118.771,347.184z"
-                style={
-                  Object {
-                    "fill": "#ffffff",
-                  }
-                }
-              />
-              <path
-                d="M356.315,127.905c2.283,0,4.473-0.855,6.571-2.565l73.087-73.089c1.707-1.903,2.562-4.093,2.562-6.567    c0-2.475-0.855-4.665-2.562-6.567c-1.91-1.709-4.093-2.568-6.571-2.568c-2.471,0-4.66,0.859-6.563,2.568l-73.087,73.089    c-1.708,1.903-2.57,4.093-2.57,6.567c0,2.474,0.862,4.661,2.57,6.567C351.846,127.05,354.037,127.905,356.315,127.905z"
-                style={
-                  Object {
-                    "fill": "#ffffff",
-                  }
-                }
-              />
-              <path
-                d="M350.607,193.005c-4-3.999-9.328-7.994-15.988-11.991l-5.14,68.238l78.23,78.508c5.328,5.328,7.987,11.807,7.987,19.417    c0,7.423-2.662,13.802-7.987,19.13l-41.977,41.686c-5.146,5.146-11.608,7.666-19.417,7.566c-7.81-0.1-14.271-2.707-19.411-7.854    l-77.946-78.225l-68.234,5.144c3.999,6.656,7.993,11.988,11.991,15.985l95.362,95.643c15.803,16.18,35.207,24.27,58.238,24.27    c22.846,0,42.154-7.898,57.957-23.695l41.977-41.685c16.173-15.8,24.27-35.115,24.27-57.958c0-22.46-7.994-41.877-23.982-58.248    L350.607,193.005z"
-                style={
-                  Object {
-                    "fill": "#ffffff",
-                  }
-                }
-              />
-              <path
-                d="M472.518,157.889c-1.711-1.709-3.901-2.565-6.563-2.565h-91.365c-2.662,0-4.853,0.855-6.563,2.565    c-1.715,1.713-2.57,3.903-2.57,6.567c0,2.666,0.855,4.856,2.57,6.567c1.711,1.712,3.901,2.568,6.563,2.568h91.365    c2.662,0,4.853-0.856,6.563-2.568c1.708-1.711,2.563-3.901,2.563-6.567C475.082,161.792,474.226,159.602,472.518,157.889z"
-                style={
-                  Object {
-                    "fill": "#ffffff",
-                  }
-                }
-              />
-              <path
-                d="M109.348,67.099c5.523-5.14,11.991-7.705,19.417-7.705c7.611,0,14.084,2.663,19.414,7.993l77.943,78.227l68.234-5.142    c-4-6.661-7.99-11.991-11.991-15.987l-95.358-95.643c-15.798-16.178-35.212-24.27-58.242-24.27c-22.841,0-42.16,7.902-57.958,23.7    L28.837,69.955C12.659,85.756,4.57,105.073,4.57,127.912c0,22.463,7.996,41.877,23.982,58.245l95.93,95.93    c3.995,4.001,9.325,7.995,15.986,11.991l5.139-68.521L67.377,147.33c-5.327-5.33-7.992-11.801-7.992-19.417    c0-7.421,2.662-13.796,7.992-19.126L109.348,67.099z"
-                style={
-                  Object {
-                    "fill": "#ffffff",
-                  }
-                }
-              />
-              <path
-                d="M164.454,365.451c-2.667,0-4.854,0.855-6.567,2.563c-1.711,1.711-2.568,3.901-2.568,6.57v91.358    c0,2.669,0.854,4.853,2.568,6.57c1.713,1.707,3.9,2.566,6.567,2.566c2.666,0,4.853-0.859,6.567-2.566    c1.713-1.718,2.568-3.901,2.568-6.57v-91.358c0-2.662-0.855-4.853-2.568-6.57C169.306,366.307,167.116,365.451,164.454,365.451z"
-                style={
-                  Object {
-                    "fill": "#ffffff",
-                  }
-                }
-              />
-            </svg>
-          </div>
           <span
             className="glyphicon glyphicon-ok"
             style={
@@ -1551,13 +1305,7 @@ exports[`VerseCheck component: Integrated View test with invalidated 1`] = `
         className="check-area"
       >
         <div
-          style={
-            Object {
-              "display": "flex",
-              "flex": 1,
-              "flexDirection": "column",
-            }
-          }
+          className="selection-area-root"
         >
           <div
             className="verse-title"
@@ -1633,31 +1381,6 @@ exports[`VerseCheck component: Integrated View test with invalidated 1`] = `
             <div
               className="instructions-area"
             >
-              <div>
-                <span>
-                  selection_invalidated
-                  <strong
-                    data-class="selection-tooltip"
-                    data-delay-hide="100"
-                    data-effect="float"
-                    data-place="top"
-                    data-tip="invalidated_tooltip"
-                    data-type="dark"
-                    style={
-                      Object {
-                        "fontSize": "0.8em",
-                        "verticalAlign": "super",
-                      }
-                    }
-                  >
-                    1
-                  </strong>
-                </span>
-                <div
-                  className="__react_component_tooltip place-top type-dark "
-                  data-id="tooltip"
-                />
-              </div>
               <span>
                 please_select
               </span>
@@ -1670,7 +1393,7 @@ exports[`VerseCheck component: Integrated View test with invalidated 1`] = `
                     }
                   }
                 >
-                  ""
+                  "undefined"
                 </strong>
               </span>
               <br />
@@ -1717,7 +1440,6 @@ exports[`VerseCheck component: Integrated View test with invalidated 1`] = `
                   />
                 </svg>
                 <input
-                  checked={false}
                   className="MuiPrivateSwitchBase-input-21"
                   data-indeterminate={false}
                   disabled={false}
@@ -1848,14 +1570,7 @@ exports[`VerseCheck component: Integrated View test with verseEdit 1`] = `
   className="verse-check"
 >
   <div
-    style={
-      Object {
-        "display": "flex",
-        "flexDirection": "column",
-        "height": "100%",
-        "width": "100%",
-      }
-    }
+    className="verse-check-flex"
   >
     <div
       className="verse-check-card"
@@ -1891,10 +1606,10 @@ exports[`VerseCheck component: Integrated View test with verseEdit 1`] = `
               Object {
                 "color": "var(--reverse-color)",
                 "margin": "0px 20px",
-                "opacity": 1,
+                "opacity": 0.2,
               }
             }
-            title="icons.verse_edits_found"
+            title="icons.no_verse_edits_found"
           />
           <span
             className="glyphicon glyphicon-comment"
@@ -1924,13 +1639,7 @@ exports[`VerseCheck component: Integrated View test with verseEdit 1`] = `
         className="check-area"
       >
         <div
-          style={
-            Object {
-              "display": "flex",
-              "flex": 1,
-              "flexDirection": "column",
-            }
-          }
+          className="selection-area-root"
         >
           <div
             className="verse-title"
@@ -2018,7 +1727,7 @@ exports[`VerseCheck component: Integrated View test with verseEdit 1`] = `
                     }
                   }
                 >
-                  ""
+                  "undefined"
                 </strong>
               </span>
               <br />
@@ -2065,7 +1774,6 @@ exports[`VerseCheck component: Integrated View test with verseEdit 1`] = `
                   />
                 </svg>
                 <input
-                  checked={false}
                   className="MuiPrivateSwitchBase-input-21"
                   data-indeterminate={false}
                   disabled={false}

--- a/src/VerseCheck/__tests__/fixtures/project/loadedProjectShortened.json
+++ b/src/VerseCheck/__tests__/fixtures/project/loadedProjectShortened.json
@@ -1,8927 +1,4845 @@
 {
-  "toolsReducer": {
-    "currentToolViews": {},
-    "currentToolName": "translationWords",
-    "currentToolTitle": "translationWords (Part 1)",
-    "toolsMetadata": []
-  },
-  "loginReducer": {
-    "loggedInUser": true,
-    "userdata": {
-      "id": 4232,
-      "login": "royalsix",
-      "full_name": "Jay Scott",
-      "email": "royalsix@noreply.door43.org",
-      "avatar_url": "https://git.door43.org/img/avatar_default.png",
-      "username": "royalsix",
-      "token": "817fd7e100e939b93fd362879c377cf01993c712"
-    },
-    "feedback": "",
-    "subject": "Bug Report"
-  },
-  "settingsReducer": {
-    "currentSettings": {
-      "showTutorial": false,
-      "developerMode": true,
-      "csvSaveLocation": null,
-      "online": true,
-      "onlineMode": false
-    },
-    "toolsSettings": {
-      "ScripturePane": {
-        "currentPaneSettings": [
-          "targetLanguage",
-          "bhp",
-          "ult"
-        ]
-      }
-    },
-    "onlineMode": false,
-    "csvSaveLocation": "/Users/jay/Desktop/"
-  },
-  "loaderReducer": {
-    "show": false,
-    "toolsProgress": {
-      "translationWords": {
-        "progress": 98.0392156862745
-      }
-    },
-    "reloadContent": null
-  },
-  "resourcesReducer": {
-    "bibles": {
-      "en": {
-        "ust": {
-          "2": {
-            "1": "But you, Titus, you must teach the things that help people believe the truth about God.",
-            "2": "The older men should control themselves all the time. They should live in a way that other people respect, and they should speak wisely. They should also believe the true things about God, love others truly, and continuously do these things.",
-            "3": "The older women, like the men, should live so that everyone knows that they respect God very much. They must not say bad things about other people, and they must not drink very much wine. But they should teach others what is good.",
-            "4": "In this way, they should teach the younger women to think wisely and to love their own husbands and children.",
-            "5": "The older women should also teach the younger women to think good thoughts, not to act in a bad way toward any man, to work well at home, and to do what their husbands tell them. They should do all these things so that no one will mock God's word.",
-            "6": "And concerning the younger men, teach them, too. Tell them to control themselves well.",
-            "7": "As for you, Titus my son, always show other people how to do good deeds. In what you teach show the believers what is true and also show them how serious you are about your work.",
-            "8": "Teach people in a way that no one can criticize, so that if anybody wants to stop you, other people will shame them because they really have nothing bad to say about any of us.",
-            "9": "About our brothers and their families who are slaves: They should always submit to their masters. As much as possible, they should live in a way that pleases their masters in every way, and are they should not argue with them.",
-            "10": "They must not steal even little things from their masters; instead, they should be faithful to them, and they should do everything in a way that leads people to admire all that we teach about God, who saves us.",
-            "11": "Titus, all that I have written adds up to this: Everyone is now able to know that God wishes to save them; this is his gift to them.",
-            "12": "This saving grace from God trains us, as if we were children, to say no to the desires that are found in this world. It helps us to think about things in the right way, to be honest, truthful, and fair to other people and to always keep God in our thoughts and actions while we live in this world.",
-            "13": "At the same time, God teaches us to wait for what he will certainly do in the future, which is something that will make us very happy: That is, Jesus the Messiah, our Savior and powerful God, will return to us in great splendor.",
-            "14": "He gave himself to die as the payment to free us from our lawless nature, to make us his cherished possession, a treasured people that he has made clean, a people whose greatest joy is to do what is good.",
-            "15": "Titus, speak about these things. Urge those who hear you to live as I have described. And use your full right of command to correct our brothers and sisters when it is necessary. Let no one disregard what you say."
-          },
-          "manifest": {
-            "language_id": "en",
-            "language_name": "English",
-            "direction": "ltr",
-            "subject": "Bible",
-            "resource_id": "ust",
-            "resource_title": "unfoldingWord Simplified Text",
-            "description": "Gateway Language"
-          }
-        },
-        "ult": {
-          "2": {
-            "1": {
-              "verseObjects": [
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "δέ",
-                  "morph": "Gr,CC,,,,,,,,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G11610",
-                  "content": "δὲ",
-                  "children": [
-                    {
-                      "text": "But",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "σύ",
-                  "morph": "Gr,RP,,,2N,S,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G47710",
-                  "content": "σὺ",
-                  "children": [
-                    {
-                      "text": "you",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "type": "text",
-                  "text": ","
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "λαλέω",
-                  "morph": "Gr,VTMPA2,,S,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G29800",
-                  "content": "λάλει",
-                  "children": [
-                    {
-                      "text": "speak",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "ὅς",
-                  "morph": "Gr,RD,,,,ANP,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G37390",
-                  "content": "ἃ",
-                  "children": [
-                    {
-                      "text": "what",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "πρέπω",
-                  "morph": "Gr,VIIPA3,,S,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G42410",
-                  "content": "πρέπει",
-                  "children": [
-                    {
-                      "text": "fits",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "ὁ",
-                  "morph": "Gr,RD,,,,DFS,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G35880",
-                  "content": "τῇ",
-                  "children": [
-                    {
-                      "text": "with",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "ὑγιαίνω",
-                  "morph": "Gr,VIPPA,DFS,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G51980",
-                  "content": "ὑγιαινούσῃ",
-                  "children": [
-                    {
-                      "text": "faithful",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "διδασκαλία",
-                  "morph": "Gr,N,,,,,DFS,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G13190",
-                  "content": "διδασκαλίᾳ",
-                  "children": [
-                    {
-                      "text": "instruction",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "type": "text",
-                  "text": ". \n"
-                }
-              ]
-            },
-            "2": {
-              "verseObjects": [
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "πρεσβύτης",
-                  "morph": "Gr,N,,,,,AMP,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G42460",
-                  "content": "πρεσβύτας",
-                  "children": [
-                    {
-                      "text": "Teach",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    },
-                    {
-                      "text": "older",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    },
-                    {
-                      "text": "men",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "εἰμί",
-                  "morph": "Gr,VLNPA,,,,,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G15100",
-                  "content": "εἶναι",
-                  "children": [
-                    {
-                      "text": "to",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    },
-                    {
-                      "text": "be",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "νηφάλιος",
-                  "morph": "Gr,NS,,,,AMP,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G35240",
-                  "content": "νηφαλίους",
-                  "children": [
-                    {
-                      "text": "temperate",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "type": "text",
-                  "text": ","
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "σεμνός",
-                  "morph": "Gr,NP,,,,AMP,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G45860",
-                  "content": "σεμνούς",
-                  "children": [
-                    {
-                      "text": "dignified",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "type": "text",
-                  "text": ","
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "σώφρων",
-                  "morph": "Gr,NS,,,,AMP,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G49980",
-                  "content": "σώφρονας",
-                  "children": [
-                    {
-                      "text": "sensible",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "type": "text",
-                  "text": ","
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "ὑγιαίνω",
-                  "morph": "Gr,VIPPA,AMP,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G51980",
-                  "content": "ὑγιαίνοντας",
-                  "children": [
-                    {
-                      "text": "sound",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "ὁ",
-                  "morph": "Gr,EA,,,,DFS,",
-                  "occurrence": 3,
-                  "occurrences": 3,
-                  "strong": "G35880",
-                  "content": "τῇ",
-                  "children": [
-                    {
-                      "text": "in",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 3
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "πίστις",
-                  "morph": "Gr,N,,,,,DFS,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G41020",
-                  "content": "πίστει",
-                  "children": [
-                    {
-                      "text": "faith",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "type": "text",
-                  "text": ","
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "ὁ",
-                  "morph": "Gr,EA,,,,DFS,",
-                  "occurrence": 2,
-                  "occurrences": 3,
-                  "strong": "G35880",
-                  "content": "τῇ",
-                  "children": [
-                    {
-                      "text": "in",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 2,
-                      "occurrences": 3
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "ἀγάπη",
-                  "morph": "Gr,N,,,,,DFS,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G00260",
-                  "content": "ἀγάπῃ",
-                  "children": [
-                    {
-                      "text": "love",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "type": "text",
-                  "text": ","
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "ὁ",
-                  "morph": "Gr,EA,,,,DFS,",
-                  "occurrence": 3,
-                  "occurrences": 3,
-                  "strong": "G35880",
-                  "content": "τῇ",
-                  "children": [
-                    {
-                      "text": "and",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "ὁ",
-                  "morph": "Gr,EA,,,,DFS,",
-                  "occurrence": 1,
-                  "occurrences": 3,
-                  "strong": "G35880",
-                  "content": "τῇ",
-                  "children": [
-                    {
-                      "text": "in",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 3,
-                      "occurrences": 3
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "ὑπομονή",
-                  "morph": "Gr,N,,,,,DFS,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G52810",
-                  "content": "ὑπομονῇ",
-                  "children": [
-                    {
-                      "text": "perseverance",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "type": "text",
-                  "text": ". \n"
-                }
-              ]
-            },
-            "3": {
-              "verseObjects": [
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "πρεσβῦτις",
-                  "morph": "Gr,N,,,,,AFP,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G42470",
-                  "content": "πρεσβύτιδας",
-                  "children": [
-                    {
-                      "text": "Teach",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    },
-                    {
-                      "text": "older",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    },
-                    {
-                      "text": "women",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "ὡσαύτως",
-                  "morph": "Gr,D,,,,,,,,,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G56150",
-                  "content": "ὡσαύτως",
-                  "children": [
-                    {
-                      "text": "likewise",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "ἐν",
-                  "morph": "Gr,P,,,,,D,,,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G17220",
-                  "content": "ἐν",
-                  "children": [
-                    {
-                      "text": "to",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 3
-                    },
-                    {
-                      "text": "be",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 2
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "ἱεροπρεπής",
-                  "morph": "Gr,NS,,,,AFP,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G24120",
-                  "content": "ἱεροπρεπεῖς",
-                  "children": [
-                    {
-                      "text": "reverent",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "πολλός",
-                  "morph": "Gr,EQ,,,,DMS,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G41830",
-                  "content": "πολλῷ",
-                  "children": [
-                    {
-                      "text": "in",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "κατάστημα",
-                  "morph": "Gr,N,,,,,DNS,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G26880",
-                  "content": "καταστήματι",
-                  "children": [
-                    {
-                      "text": "behavior",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "type": "text",
-                  "text": ","
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "μή",
-                  "morph": "Gr,D,,,,,,,,,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G33610",
-                  "content": "μὴ",
-                  "children": [
-                    {
-                      "text": "not",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "διάβολος",
-                  "morph": "Gr,NS,,,,AFP,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G12280",
-                  "content": "διαβόλους",
-                  "children": [
-                    {
-                      "text": "slanderers",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "μηδέ",
-                  "morph": "Gr,D,,,,,,,,,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G33660",
-                  "content": "μηδὲ",
-                  "children": [
-                    {
-                      "text": "or",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "δουλόω",
-                  "morph": "Gr,VIPEP,AFP,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G14020",
-                  "content": "δεδουλωμένας",
-                  "children": [
-                    {
-                      "text": "being",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    },
-                    {
-                      "text": "slaves",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    },
-                    {
-                      "text": "to",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 2,
-                      "occurrences": 3
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "πολλός",
-                  "morph": "Gr,EQ,,,,DMS,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G41830",
-                  "content": "πολλῷ",
-                  "children": [
-                    {
-                      "text": "much",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "οἶνος",
-                  "morph": "Gr,N,,,,,DMS,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G36310",
-                  "content": "οἴνῳ",
-                  "children": [
-                    {
-                      "text": "wine",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "type": "text",
-                  "text": ","
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "καλοδιδάσκαλος",
-                  "morph": "Gr,NS,,,,AFP,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G25670",
-                  "content": "καλοδιδασκάλους",
-                  "children": [
-                    {
-                      "text": "but",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "διάβολος",
-                  "morph": "Gr,NS,,,,AFP,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G12280",
-                  "content": "διαβόλους",
-                  "children": [
-                    {
-                      "text": "to",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 3,
-                      "occurrences": 3
-                    },
-                    {
-                      "text": "be",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 2,
-                      "occurrences": 2
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "καλοδιδάσκαλος",
-                  "morph": "Gr,NS,,,,AFP,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G25670",
-                  "content": "καλοδιδασκάλους",
-                  "children": [
-                    {
-                      "text": "teachers",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    },
-                    {
-                      "text": "of",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    },
-                    {
-                      "text": "what",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    },
-                    {
-                      "text": "is",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    },
-                    {
-                      "text": "good",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "type": "text",
-                  "text": ". \n"
-                }
-              ]
-            },
-            "4": {
-              "verseObjects": [
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "ἵνα",
-                  "morph": "Gr,CS,,,,,,,,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G24430",
-                  "content": "ἵνα",
-                  "children": [
-                    {
-                      "text": "In",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    },
-                    {
-                      "text": "this",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    },
-                    {
-                      "text": "way",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "σωφρονίζω",
-                  "morph": "Gr,VTSPA3,,P,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G49940",
-                  "content": "σωφρονίζωσι",
-                  "children": [
-                    {
-                      "text": "they",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    },
-                    {
-                      "text": "may",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    },
-                    {
-                      "text": "train",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "ὁ",
-                  "morph": "Gr,EA,,,,AFP,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G35880",
-                  "content": "τὰς",
-                  "children": [
-                    {
-                      "text": "the",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "νέος",
-                  "morph": "Gr,NS,,,,AFP,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G35010",
-                  "content": "νέας",
-                  "children": [
-                    {
-                      "text": "younger",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    },
-                    {
-                      "text": "women",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "εἰμί",
-                  "morph": "Gr,VLNPA,,,,,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G15100",
-                  "content": "εἶναι",
-                  "children": [
-                    {
-                      "text": "to",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "φίλανδρος",
-                  "morph": "Gr,NS,,,,AFP,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G53620",
-                  "content": "φιλάνδρους",
-                  "children": [
-                    {
-                      "text": "love",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    },
-                    {
-                      "text": "their",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    },
-                    {
-                      "text": "own",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    },
-                    {
-                      "text": "husbands",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "φιλότεκνος",
-                  "morph": "Gr,NS,,,,AFP,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G53880",
-                  "content": "φιλοτέκνους",
-                  "children": [
-                    {
-                      "text": "and",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    },
-                    {
-                      "text": "children",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "type": "text",
-                  "text": ", \n"
-                }
-              ]
-            },
-            "5": {
-              "verseObjects": [
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "σώφρων",
-                  "morph": "Gr,NS,,,,AFP,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G49980",
-                  "content": "σώφρονας",
-                  "children": [
-                    {
-                      "text": "to",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 2
-                    },
-                    {
-                      "text": "be",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 2
-                    },
-                    {
-                      "text": "sensible",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "type": "text",
-                  "text": ","
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "ἁγνός",
-                  "morph": "Gr,NS,,,,AFP,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G00530",
-                  "content": "ἁγνάς",
-                  "children": [
-                    {
-                      "text": "pure",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "type": "text",
-                  "text": ","
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "ἀγαθός",
-                  "morph": "Gr,NS,,,,AFP,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G00180",
-                  "content": "ἀγαθάς",
-                  "children": [
-                    {
-                      "text": "good",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "οἰκουργός",
-                  "morph": "Gr,NS,,,,AFP,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G36260",
-                  "content": "οἰκουργούς",
-                  "children": [
-                    {
-                      "text": "housekeepers",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "type": "text",
-                  "text": ","
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "ὑποτάσσω",
-                  "morph": "Gr,VIPPP,AFP,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G52930",
-                  "content": "ὑποτασσομένας",
-                  "children": [
-                    {
-                      "text": "and",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    },
-                    {
-                      "text": "obedient",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "ὁ",
-                  "morph": "Gr,EP,,,,DMP,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G35880",
-                  "content": "τοῖς",
-                  "children": [
-                    {
-                      "text": "to",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 2,
-                      "occurrences": 2
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "ἴδιος",
-                  "morph": "Gr,EF,,,,DMP,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G23980",
-                  "content": "ἰδίοις",
-                  "children": [
-                    {
-                      "text": "their",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    },
-                    {
-                      "text": "own",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "ἀνήρ",
-                  "morph": "Gr,N,,,,,DMP,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G04350",
-                  "content": "ἀνδράσιν",
-                  "children": [
-                    {
-                      "text": "husbands",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "type": "text",
-                  "text": ","
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "ἵνα",
-                  "morph": "Gr,CS,,,,,,,,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G24430",
-                  "content": "ἵνα",
-                  "children": [
-                    {
-                      "text": "so",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    },
-                    {
-                      "text": "that",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "ὁ",
-                  "morph": "Gr,EA,,,,GMS,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G35880",
-                  "content": "τοῦ",
-                  "children": [
-                    {
-                      "tag": "zaln",
-                      "type": "milestone",
-                      "lemma": "θεός",
-                      "morph": "Gr,N,,,,,GMS,",
-                      "occurrence": 1,
-                      "occurrences": 1,
-                      "strong": "G23160",
-                      "content": "Θεοῦ",
-                      "children": [
-                        {
-                          "text": "God",
-                          "tag": "w",
-                          "type": "word",
-                          "occurrence": 1,
-                          "occurrences": 1
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "type": "text",
-                  "text": "'"
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "ὁ",
-                  "morph": "Gr,EA,,,,GMS,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G35880",
-                  "content": "τοῦ",
-                  "children": [
-                    {
-                      "tag": "zaln",
-                      "type": "milestone",
-                      "lemma": "θεός",
-                      "morph": "Gr,N,,,,,GMS,",
-                      "occurrence": 1,
-                      "occurrences": 1,
-                      "strong": "G23160",
-                      "content": "Θεοῦ",
-                      "children": [
-                        {
-                          "text": "s",
-                          "tag": "w",
-                          "type": "word",
-                          "occurrence": 1,
-                          "occurrences": 1
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "ὁ",
-                  "morph": "Gr,EA,,,,NMS,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G35880",
-                  "content": "ὁ",
-                  "children": [
-                    {
-                      "tag": "zaln",
-                      "type": "milestone",
-                      "lemma": "λόγος",
-                      "morph": "Gr,N,,,,,NMS,",
-                      "occurrence": 1,
-                      "occurrences": 1,
-                      "strong": "G30560",
-                      "content": "λόγος",
-                      "children": [
-                        {
-                          "text": "word",
-                          "tag": "w",
-                          "type": "word",
-                          "occurrence": 1,
-                          "occurrences": 1
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "μή",
-                  "morph": "Gr,D,,,,,,,,,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G33610",
-                  "content": "μὴ",
-                  "children": [
-                    {
-                      "text": "may",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    },
-                    {
-                      "text": "not",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "βλασφημέω",
-                  "morph": "Gr,VISPP3,,S,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G09870",
-                  "content": "βλασφημῆται",
-                  "children": [
-                    {
-                      "text": "be",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 2,
-                      "occurrences": 2
-                    },
-                    {
-                      "text": "insulted",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "type": "text",
-                  "text": ". \n"
-                }
-              ]
-            },
-            "6": {
-              "verseObjects": [
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "ὡσαύτως",
-                  "morph": "Gr,D,,,,,,,,,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G56150",
-                  "content": "ὡσαύτως",
-                  "children": [
-                    {
-                      "text": "In",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "ὁ",
-                  "morph": "Gr,EA,,,,AMP,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G35880",
-                  "content": "τοὺς",
-                  "children": [
-                    {
-                      "text": "the",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 2
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "ὡσαύτως",
-                  "morph": "Gr,D,,,,,,,,,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G56150",
-                  "content": "ὡσαύτως",
-                  "children": [
-                    {
-                      "text": "same",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    },
-                    {
-                      "text": "way",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "type": "text",
-                  "text": ","
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "παρακαλέω",
-                  "morph": "Gr,VTMPA2,,S,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G38700",
-                  "content": "παρακάλει",
-                  "children": [
-                    {
-                      "text": "encourage",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "ὡσαύτως",
-                  "morph": "Gr,D,,,,,,,,,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G56150",
-                  "content": "ὡσαύτως",
-                  "children": [
-                    {
-                      "text": "the",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 2,
-                      "occurrences": 2
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "νεώτερος",
-                  "morph": "Gr,AA,,,,AMPC",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G35125",
-                  "content": "νεωτέρους",
-                  "children": [
-                    {
-                      "text": "younger",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    },
-                    {
-                      "text": "men",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "σωφρονέω",
-                  "morph": "Gr,VINPA,,,,,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G49930",
-                  "content": "σωφρονεῖν",
-                  "children": [
-                    {
-                      "text": "to",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    },
-                    {
-                      "text": "use",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    },
-                    {
-                      "text": "good",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    },
-                    {
-                      "text": "sense",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "type": "text",
-                  "text": ". \n"
-                }
-              ]
-            },
-            "7": {
-              "verseObjects": [
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "περί",
-                  "morph": "Gr,P,,,,,A,,,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G40120",
-                  "content": "περὶ",
-                  "children": [
-                    {
-                      "text": "In",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 2
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "πᾶς",
-                  "morph": "Gr,RI,,,,ANP,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G39560",
-                  "content": "πάντα",
-                  "children": [
-                    {
-                      "text": "all",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    },
-                    {
-                      "text": "ways",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "παρέχω",
-                  "morph": "Gr,VTPPM,NMS,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G39300",
-                  "content": "παρεχόμενος",
-                  "children": [
-                    {
-                      "text": "present",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "σεαυτοῦ",
-                  "morph": "Gr,RE,,,2AMS,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G45720",
-                  "content": "σεαυτὸν",
-                  "children": [
-                    {
-                      "text": "yourself",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "τύπος",
-                  "morph": "Gr,N,,,,,AMS,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G51790",
-                  "content": "τύπον",
-                  "children": [
-                    {
-                      "text": "as",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    },
-                    {
-                      "text": "an",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    },
-                    {
-                      "text": "example",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "καλός",
-                  "morph": "Gr,AA,,,,GNP,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G25700",
-                  "content": "καλῶν",
-                  "children": [
-                    {
-                      "text": "of",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    },
-                    {
-                      "text": "good",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "ἔργον",
-                  "morph": "Gr,N,,,,,GNP,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G20410",
-                  "content": "ἔργων",
-                  "children": [
-                    {
-                      "text": "works",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "type": "text",
-                  "text": "."
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "ἐν",
-                  "morph": "Gr,P,,,,,D,,,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G17220",
-                  "content": "ἐν",
-                  "children": [
-                    {
-                      "text": "In",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 2,
-                      "occurrences": 2
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "ὁ",
-                  "morph": "Gr,EP,,,,DFS,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G35880",
-                  "content": "τῇ",
-                  "children": [
-                    {
-                      "text": "your",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "διδασκαλία",
-                  "morph": "Gr,N,,,,,DFS,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G13190",
-                  "content": "διδασκαλίᾳ",
-                  "children": [
-                    {
-                      "text": "teaching",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "type": "text",
-                  "text": ","
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "ἀφθορία",
-                  "morph": "Gr,N,,,,,AFS,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G08627",
-                  "content": "ἀφθορίαν",
-                  "children": [
-                    {
-                      "text": "show",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    },
-                    {
-                      "text": "integrity",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "type": "text",
-                  "text": ","
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "σεμνότης",
-                  "morph": "Gr,N,,,,,AFS,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G45870",
-                  "content": "σεμνότητα",
-                  "children": [
-                    {
-                      "text": "dignity",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "type": "text",
-                  "text": ", \n"
-                }
-              ]
-            },
-            "8": {
-              "verseObjects": [
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "λόγος",
-                  "morph": "Gr,N,,,,,AMS,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G30560",
-                  "content": "λόγον",
-                  "children": [
-                    {
-                      "text": "and",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    },
-                    {
-                      "text": "a",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "ὑγιής",
-                  "morph": "Gr,AA,,,,AMS,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G51990",
-                  "content": "ὑγιῆ",
-                  "children": [
-                    {
-                      "text": "correct",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "λόγος",
-                  "morph": "Gr,N,,,,,AMS,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G30560",
-                  "content": "λόγον",
-                  "children": [
-                    {
-                      "text": "message",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "ἀκατάγνωστος",
-                  "morph": "Gr,NS,,,,AMS,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G01760",
-                  "content": "ἀκατάγνωστον",
-                  "children": [
-                    {
-                      "text": "that",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 2
-                    },
-                    {
-                      "text": "is",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    },
-                    {
-                      "text": "above",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    },
-                    {
-                      "text": "criticism",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "type": "text",
-                  "text": ","
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "ἵνα",
-                  "morph": "Gr,CS,,,,,,,,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G24430",
-                  "content": "ἵνα",
-                  "children": [
-                    {
-                      "text": "so",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    },
-                    {
-                      "text": "that",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 2,
-                      "occurrences": 2
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "ὁ",
-                  "morph": "Gr,RD,,,,NMS,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G35880",
-                  "content": "ὁ",
-                  "children": [
-                    {
-                      "text": "anyone",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "ἐκ",
-                  "morph": "Gr,P,,,,,G,,,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G15370",
-                  "content": "ἐξ",
-                  "children": [
-                    {
-                      "text": "who",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "ἐναντίος",
-                  "morph": "Gr,NS,,,,GFS,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G17270",
-                  "content": "ἐναντίας",
-                  "children": [
-                    {
-                      "text": "opposes",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    },
-                    {
-                      "text": "you",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "ἐντρέπω",
-                  "morph": "Gr,VISAP3,,S,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G17880",
-                  "content": "ἐντραπῇ",
-                  "children": [
-                    {
-                      "text": "may",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    },
-                    {
-                      "text": "be",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    },
-                    {
-                      "text": "ashamed",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "μηδείς",
-                  "morph": "Gr,RI,,,,ANS,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G33670",
-                  "content": "μηδὲν",
-                  "children": [
-                    {
-                      "text": "because",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "ἔχω",
-                  "morph": "Gr,VTPPA,NMS,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G21920",
-                  "content": "ἔχων",
-                  "children": [
-                    {
-                      "text": "they",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    },
-                    {
-                      "text": "have",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "μηδείς",
-                  "morph": "Gr,RI,,,,ANS,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G33670",
-                  "content": "μηδὲν",
-                  "children": [
-                    {
-                      "text": "nothing",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "φαῦλος",
-                  "morph": "Gr,NS,,,,ANS,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G53370",
-                  "content": "φαῦλον",
-                  "children": [
-                    {
-                      "text": "bad",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "λέγω",
-                  "morph": "Gr,VTNPA,,,,,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G30040",
-                  "content": "λέγειν",
-                  "children": [
-                    {
-                      "text": "to",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    },
-                    {
-                      "text": "say",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "περί",
-                  "morph": "Gr,P,,,,,G,,,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G40120",
-                  "content": "περὶ",
-                  "children": [
-                    {
-                      "text": "about",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "ἐγώ",
-                  "morph": "Gr,RP,,,1G,P,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G14730",
-                  "content": "ἡμῶν",
-                  "children": [
-                    {
-                      "text": "us",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "type": "text",
-                  "text": ". \n"
-                }
-              ]
-            },
-            "9": {
-              "verseObjects": [
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "δοῦλος",
-                  "morph": "Gr,N,,,,,AMP,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G14010",
-                  "content": "δούλους",
-                  "children": [
-                    {
-                      "text": "Teach",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    },
-                    {
-                      "text": "slaves",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "εὐάρεστος",
-                  "morph": "Gr,NP,,,,AMP,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G21010",
-                  "content": "εὐαρέστους",
-                  "children": [
-                    {
-                      "text": "to",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 2
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "ὑποτάσσω",
-                  "morph": "Gr,VINPM,,,,,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G52930",
-                  "content": "ὑποτάσσεσθαι",
-                  "children": [
-                    {
-                      "text": "obey",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "ἴδιος",
-                  "morph": "Gr,EF,,,,DMP,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G23980",
-                  "content": "ἰδίοις",
-                  "children": [
-                    {
-                      "text": "their",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "δεσπότης",
-                  "morph": "Gr,N,,,,,DMP,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G12030",
-                  "content": "δεσπόταις",
-                  "children": [
-                    {
-                      "text": "masters",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "ἐν",
-                  "morph": "Gr,P,,,,,D,,,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G17220",
-                  "content": "ἐν",
-                  "children": [
-                    {
-                      "text": "in",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "πᾶς",
-                  "morph": "Gr,RI,,,,DNP,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G39560",
-                  "content": "πᾶσιν",
-                  "children": [
-                    {
-                      "text": "everything",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "type": "text",
-                  "text": ","
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "ὑποτάσσω",
-                  "morph": "Gr,VINPM,,,,,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G52930",
-                  "content": "ὑποτάσσεσθαι",
-                  "children": [
-                    {
-                      "text": "to",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 2,
-                      "occurrences": 2
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "εὐάρεστος",
-                  "morph": "Gr,NP,,,,AMP,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G21010",
-                  "content": "εὐαρέστους",
-                  "children": [
-                    {
-                      "text": "please",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    },
-                    {
-                      "text": "them",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 2
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "εἰμί",
-                  "morph": "Gr,VLNPA,,,,,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G15100",
-                  "content": "εἶναι",
-                  "children": [
-                    {
-                      "text": "and",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "μή",
-                  "morph": "Gr,D,,,,,,,,,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G33610",
-                  "content": "μὴ",
-                  "children": [
-                    {
-                      "text": "not",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "ἀντιλέγω",
-                  "morph": "Gr,VIPPA,AMP,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G04830",
-                  "content": "ἀντιλέγοντας",
-                  "children": [
-                    {
-                      "text": "argue",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    },
-                    {
-                      "text": "with",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    },
-                    {
-                      "text": "them",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 2,
-                      "occurrences": 2
-                    }
-                  ]
-                },
-                {
-                  "type": "text",
-                  "text": ", \n"
-                }
-              ]
-            },
-            "10": {
-              "verseObjects": [
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "νοσφίζω",
-                  "morph": "Gr,VIPPM,AMP,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G35570",
-                  "content": "νοσφιζομένους",
-                  "children": [
-                    {
-                      "text": "to",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 3
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "μή",
-                  "morph": "Gr,D,,,,,,,,,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G33610",
-                  "content": "μὴ",
-                  "children": [
-                    {
-                      "text": "not",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "νοσφίζω",
-                  "morph": "Gr,VIPPM,AMP,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G35570",
-                  "content": "νοσφιζομένους",
-                  "children": [
-                    {
-                      "text": "steal",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    },
-                    {
-                      "text": "from",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    },
-                    {
-                      "text": "them",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "type": "text",
-                  "text": ","
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "ἀλλά",
-                  "morph": "Gr,CC,,,,,,,,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G02350",
-                  "content": "ἀλλὰ",
-                  "children": [
-                    {
-                      "text": "but",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    },
-                    {
-                      "text": "instead",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "ἐνδείκνυμι",
-                  "morph": "Gr,VTPPM,AMP,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G17310",
-                  "content": "ἐνδεικνυμένους",
-                  "children": [
-                    {
-                      "text": "to",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 2,
-                      "occurrences": 3
-                    },
-                    {
-                      "text": "demonstrate",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "πᾶς",
-                  "morph": "Gr,EQ,,,,AFS,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G39560",
-                  "content": "πᾶσαν",
-                  "children": [
-                    {
-                      "text": "all",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "ἀγαθός",
-                  "morph": "Gr,NS,,,,AFS,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G00180",
-                  "content": "ἀγαθήν",
-                  "children": [
-                    {
-                      "text": "good",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "πίστις",
-                  "morph": "Gr,N,,,,,AFS,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G41020",
-                  "content": "πίστιν",
-                  "children": [
-                    {
-                      "text": "faith",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "type": "text",
-                  "text": ","
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "ἵνα",
-                  "morph": "Gr,CS,,,,,,,,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G24430",
-                  "content": "ἵνα",
-                  "children": [
-                    {
-                      "text": "so",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    },
-                    {
-                      "text": "that",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "ἐν",
-                  "morph": "Gr,P,,,,,D,,,",
-                  "occurrence": 1,
-                  "occurrences": 2,
-                  "strong": "G17220",
-                  "content": "ἐν",
-                  "children": [
-                    {
-                      "text": "in",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "πᾶς",
-                  "morph": "Gr,RI,,,,DNP,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G39560",
-                  "content": "πᾶσιν",
-                  "children": [
-                    {
-                      "text": "every",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    },
-                    {
-                      "text": "way",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "κοσμέω",
-                  "morph": "Gr,VTSPA3,,P,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G28850",
-                  "content": "κοσμῶσιν",
-                  "children": [
-                    {
-                      "text": "they",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    },
-                    {
-                      "text": "may",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    },
-                    {
-                      "text": "bring",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    },
-                    {
-                      "text": "credit",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "ὁ",
-                  "morph": "Gr,EA,,,,AFS,",
-                  "occurrence": 1,
-                  "occurrences": 2,
-                  "strong": "G35880",
-                  "content": "τὴν",
-                  "children": [
-                    {
-                      "text": "to",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 3,
-                      "occurrences": 3
-                    },
-                    {
-                      "text": "the",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "διδασκαλία",
-                  "morph": "Gr,N,,,,,AFS,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G13190",
-                  "content": "διδασκαλίαν",
-                  "children": [
-                    {
-                      "text": "teaching",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "ὁ",
-                  "morph": "Gr,RD,,,,AFS,",
-                  "occurrence": 2,
-                  "occurrences": 2,
-                  "strong": "G35880",
-                  "content": "τὴν",
-                  "children": [
-                    {
-                      "text": "about",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "θεός",
-                  "morph": "Gr,N,,,,,GMS,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G23160",
-                  "content": "Θεοῦ",
-                  "children": [
-                    {
-                      "text": "God",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "ἐγώ",
-                  "morph": "Gr,RP,,,1G,P,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G14730",
-                  "content": "ἡμῶν",
-                  "children": [
-                    {
-                      "text": "our",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "ὁ",
-                  "morph": "Gr,EA,,,,GMS,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G35880",
-                  "content": "τοῦ",
-                  "children": [
-                    {
-                      "tag": "zaln",
-                      "type": "milestone",
-                      "lemma": "σωτήρ",
-                      "morph": "Gr,N,,,,,GMS,",
-                      "occurrence": 1,
-                      "occurrences": 1,
-                      "strong": "G49900",
-                      "content": "Σωτῆρος",
-                      "children": [
-                        {
-                          "text": "Savior",
-                          "tag": "w",
-                          "type": "word",
-                          "occurrence": 1,
-                          "occurrences": 1
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "type": "text",
-                  "text": ". \n"
-                }
-              ]
-            },
-            "11": {
-              "verseObjects": [
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "γάρ",
-                  "morph": "Gr,CC,,,,,,,,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G10630",
-                  "content": "γὰρ",
-                  "children": [
-                    {
-                      "text": "For",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "ὁ",
-                  "morph": "Gr,EA,,,,NFS,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G35880",
-                  "content": "ἡ",
-                  "children": [
-                    {
-                      "text": "the",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 2
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "χάρις",
-                  "morph": "Gr,N,,,,,NFS,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G54850",
-                  "content": "χάρις",
-                  "children": [
-                    {
-                      "text": "grace",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "ὁ",
-                  "morph": "Gr,EA,,,,GMS,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G35880",
-                  "content": "τοῦ",
-                  "children": [
-                    {
-                      "tag": "zaln",
-                      "type": "milestone",
-                      "lemma": "θεός",
-                      "morph": "Gr,N,,,,,GMS,",
-                      "occurrence": 1,
-                      "occurrences": 1,
-                      "strong": "G23160",
-                      "content": "Θεοῦ",
-                      "children": [
-                        {
-                          "text": "of",
-                          "tag": "w",
-                          "type": "word",
-                          "occurrence": 1,
-                          "occurrences": 2
-                        },
-                        {
-                          "text": "God",
-                          "tag": "w",
-                          "type": "word",
-                          "occurrence": 1,
-                          "occurrences": 1
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "ἐπιφαίνω",
-                  "morph": "Gr,VIIAP3,,S,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G20140",
-                  "content": "ἐπεφάνη",
-                  "children": [
-                    {
-                      "text": "has",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    },
-                    {
-                      "text": "appeared",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "σωτήριος",
-                  "morph": "Gr,NS,,,,NMS,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G49920",
-                  "content": "σωτήριος",
-                  "children": [
-                    {
-                      "text": "for",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    },
-                    {
-                      "text": "the",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 2,
-                      "occurrences": 2
-                    },
-                    {
-                      "text": "salvation",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "πᾶς",
-                  "morph": "Gr,EQ,,,,DMP,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G39560",
-                  "content": "πᾶσιν",
-                  "children": [
-                    {
-                      "text": "of",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 2,
-                      "occurrences": 2
-                    },
-                    {
-                      "text": "all",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "ἄνθρωπος",
-                  "morph": "Gr,N,,,,,DMP,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G04440",
-                  "content": "ἀνθρώποις",
-                  "children": [
-                    {
-                      "text": "people",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "type": "text",
-                  "text": ". \n"
-                }
-              ]
-            },
-            "12": {
-              "verseObjects": [
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "παιδεύω",
-                  "morph": "Gr,VTPPA,NFS,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G38110",
-                  "content": "παιδεύουσα",
-                  "children": [
-                    {
-                      "text": "It",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    },
-                    {
-                      "text": "trains",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "ἐγώ",
-                  "morph": "Gr,RP,,,1A,P,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G14730",
-                  "content": "ἡμᾶς",
-                  "children": [
-                    {
-                      "text": "us",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "ἵνα",
-                  "morph": "Gr,CS,,,,,,,,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G24430",
-                  "content": "ἵνα",
-                  "children": [
-                    {
-                      "text": "to",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 2
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "ἀρνέομαι",
-                  "morph": "Gr,VTPAM,NMP,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G07200",
-                  "content": "ἀρνησάμενοι",
-                  "children": [
-                    {
-                      "text": "reject",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "ὁ",
-                  "morph": "Gr,EA,,,,AFS,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G35880",
-                  "content": "τὴν",
-                  "children": [
-                    {
-                      "tag": "zaln",
-                      "type": "milestone",
-                      "lemma": "ἀσέβεια",
-                      "morph": "Gr,N,,,,,AFS,",
-                      "occurrence": 1,
-                      "occurrences": 1,
-                      "strong": "G07630",
-                      "content": "ἀσέβειαν",
-                      "children": [
-                        {
-                          "text": "godlessness",
-                          "tag": "w",
-                          "type": "word",
-                          "occurrence": 1,
-                          "occurrences": 1
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "καί",
-                  "morph": "Gr,CC,,,,,,,,",
-                  "occurrence": 3,
-                  "occurrences": 3,
-                  "strong": "G25320",
-                  "content": "καὶ",
-                  "children": [
-                    {
-                      "text": "and",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 3
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "ὁ",
-                  "morph": "Gr,EA,,,,AFP,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G35880",
-                  "content": "τὰς",
-                  "children": [
-                    {
-                      "tag": "zaln",
-                      "type": "milestone",
-                      "lemma": "κοσμικός",
-                      "morph": "Gr,AA,,,,AFP,",
-                      "occurrence": 1,
-                      "occurrences": 1,
-                      "strong": "G28860",
-                      "content": "κοσμικὰς",
-                      "children": [
-                        {
-                          "text": "worldly",
-                          "tag": "w",
-                          "type": "word",
-                          "occurrence": 1,
-                          "occurrences": 1
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "ἐπιθυμία",
-                  "morph": "Gr,N,,,,,AFP,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G19390",
-                  "content": "ἐπιθυμίας",
-                  "children": [
-                    {
-                      "text": "passions",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "type": "text",
-                  "text": ","
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "καί",
-                  "morph": "Gr,CC,,,,,,,,",
-                  "occurrence": 1,
-                  "occurrences": 3,
-                  "strong": "G25320",
-                  "content": "καὶ",
-                  "children": [
-                    {
-                      "text": "and",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 2,
-                      "occurrences": 3
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "σωφρόνως",
-                  "morph": "Gr,D,,,,,,,,,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G49960",
-                  "content": "σωφρόνως",
-                  "children": [
-                    {
-                      "text": "to",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 2,
-                      "occurrences": 2
-                    },
-                    {
-                      "text": "live",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    },
-                    {
-                      "text": "self",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "type": "text",
-                  "text": "-"
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "σωφρόνως",
-                  "morph": "Gr,D,,,,,,,,,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G49960",
-                  "content": "σωφρόνως",
-                  "children": [
-                    {
-                      "text": "controlled",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "type": "text",
-                  "text": ","
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "δικαίως",
-                  "morph": "Gr,D,,,,,,,,,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G13460",
-                  "content": "δικαίως",
-                  "children": [
-                    {
-                      "text": "upright",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "type": "text",
-                  "text": ","
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "καί",
-                  "morph": "Gr,CC,,,,,,,,",
-                  "occurrence": 2,
-                  "occurrences": 3,
-                  "strong": "G25320",
-                  "content": "καὶ",
-                  "children": [
-                    {
-                      "text": "and",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 3,
-                      "occurrences": 3
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "εὐσεβῶς",
-                  "morph": "Gr,D,,,,,,,,,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G21530",
-                  "content": "εὐσεβῶς",
-                  "children": [
-                    {
-                      "text": "godly",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "ζάω",
-                  "morph": "Gr,VISAA1,,P,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G21980",
-                  "content": "ζήσωμεν",
-                  "children": [
-                    {
-                      "text": "lives",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "ἐν",
-                  "morph": "Gr,P,,,,,D,,,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G17220",
-                  "content": "ἐν",
-                  "children": [
-                    {
-                      "text": "in",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "ὁ",
-                  "morph": "Gr,EA,,,,DMS,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G35880",
-                  "content": "τῷ",
-                  "children": [
-                    {
-                      "tag": "zaln",
-                      "type": "milestone",
-                      "lemma": "νῦν",
-                      "morph": "Gr,D,,,,,,,,,",
-                      "occurrence": 1,
-                      "occurrences": 1,
-                      "strong": "G35680",
-                      "content": "νῦν",
-                      "children": [
-                        {
-                          "text": "this",
-                          "tag": "w",
-                          "type": "word",
-                          "occurrence": 1,
-                          "occurrences": 1
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "αἰών",
-                  "morph": "Gr,N,,,,,DMS,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G01650",
-                  "content": "αἰῶνι",
-                  "children": [
-                    {
-                      "text": "age",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "type": "text",
-                  "text": ", \n"
-                }
-              ]
-            },
-            "13": {
-              "verseObjects": [
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "προσδέχομαι",
-                  "morph": "Gr,VTPPM,NMP,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G43270",
-                  "content": "προσδεχόμενοι",
-                  "children": [
-                    {
-                      "text": "while",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    },
-                    {
-                      "text": "we",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    },
-                    {
-                      "text": "look",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    },
-                    {
-                      "text": "forward",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    },
-                    {
-                      "text": "to",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    },
-                    {
-                      "text": "receiving",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "ὁ",
-                  "morph": "Gr,EA,,,,AFS,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G35880",
-                  "content": "τὴν",
-                  "children": [
-                    {
-                      "text": "our",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 2
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "μακάριος",
-                  "morph": "Gr,AA,,,,AFS,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G31070",
-                  "content": "μακαρίαν",
-                  "children": [
-                    {
-                      "text": "blessed",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "ἐλπίς",
-                  "morph": "Gr,N,,,,,AFS,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G16800",
-                  "content": "ἐλπίδα",
-                  "children": [
-                    {
-                      "text": "hope",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "type": "text",
-                  "text": ","
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "καί",
-                  "morph": "Gr,CC,,,,,,,,",
-                  "occurrence": 1,
-                  "occurrences": 2,
-                  "strong": "G25320",
-                  "content": "καὶ",
-                  "children": [
-                    {
-                      "tag": "zaln",
-                      "type": "milestone",
-                      "lemma": "ἐπιφάνεια",
-                      "morph": "Gr,N,,,,,AFS,",
-                      "occurrence": 1,
-                      "occurrences": 1,
-                      "strong": "G20150",
-                      "content": "ἐπιφάνειαν",
-                      "children": [
-                        {
-                          "text": "the",
-                          "tag": "w",
-                          "type": "word",
-                          "occurrence": 1,
-                          "occurrences": 2
-                        },
-                        {
-                          "text": "appearance",
-                          "tag": "w",
-                          "type": "word",
-                          "occurrence": 1,
-                          "occurrences": 1
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "ὁ",
-                  "morph": "Gr,EA,,,,GFS,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G35880",
-                  "content": "τῆς",
-                  "children": [
-                    {
-                      "text": "of",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 2
-                    },
-                    {
-                      "text": "the",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 2,
-                      "occurrences": 2
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "δόξα",
-                  "morph": "Gr,N,,,,,GFS,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G13910",
-                  "content": "δόξης",
-                  "children": [
-                    {
-                      "text": "glory",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "ὁ",
-                  "morph": "Gr,EA,,,,GMS,",
-                  "occurrence": 1,
-                  "occurrences": 2,
-                  "strong": "G35880",
-                  "content": "τοῦ",
-                  "children": [
-                    {
-                      "text": "of",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 2,
-                      "occurrences": 2
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "ἐγώ",
-                  "morph": "Gr,RP,,,1G,P,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G14730",
-                  "content": "ἡμῶν",
-                  "children": [
-                    {
-                      "text": "our",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 2,
-                      "occurrences": 2
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "μέγας",
-                  "morph": "Gr,AA,,,,GMS,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G31730",
-                  "content": "μεγάλου",
-                  "children": [
-                    {
-                      "text": "great",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "θεός",
-                  "morph": "Gr,N,,,,,GMS,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G23160",
-                  "content": "Θεοῦ",
-                  "children": [
-                    {
-                      "text": "God",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "καί",
-                  "morph": "Gr,CC,,,,,,,,",
-                  "occurrence": 2,
-                  "occurrences": 2,
-                  "strong": "G25320",
-                  "content": "καὶ",
-                  "children": [
-                    {
-                      "text": "and",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "σωτήρ",
-                  "morph": "Gr,N,,,,,GMS,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G49900",
-                  "content": "Σωτῆρος",
-                  "children": [
-                    {
-                      "text": "Savior",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "Ἰησοῦς",
-                  "morph": "Gr,N,,,,,GMS,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G24240",
-                  "content": "Ἰησοῦ",
-                  "children": [
-                    {
-                      "text": "Jesus",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "χριστός",
-                  "morph": "Gr,N,,,,,GMS,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G55470",
-                  "content": "Χριστοῦ",
-                  "children": [
-                    {
-                      "text": "Christ",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "type": "text",
-                  "text": ". \n"
-                }
-              ]
-            },
-            "14": {
-              "verseObjects": [
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "ὅς",
-                  "morph": "Gr,RR,,,,NMS,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G37390",
-                  "content": "ὃς",
-                  "children": [
-                    {
-                      "text": "Jesus",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "δίδωμι",
-                  "morph": "Gr,VTIAA3,,S,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G13250",
-                  "content": "ἔδωκεν",
-                  "children": [
-                    {
-                      "text": "gave",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "ἑαυτοῦ",
-                  "morph": "Gr,RE,,,3AMS,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G14380",
-                  "content": "ἑαυτὸν",
-                  "children": [
-                    {
-                      "text": "himself",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 2
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "ὑπέρ",
-                  "morph": "Gr,P,,,,,G,,,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G52280",
-                  "content": "ὑπὲρ",
-                  "children": [
-                    {
-                      "text": "for",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 2
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "ἐγώ",
-                  "morph": "Gr,RP,,,1G,P,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G14730",
-                  "content": "ἡμῶν",
-                  "children": [
-                    {
-                      "text": "us",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 2
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "ἵνα",
-                  "morph": "Gr,CS,,,,,,,,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G24430",
-                  "content": "ἵνα",
-                  "children": [
-                    {
-                      "text": "in",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    },
-                    {
-                      "text": "order",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    },
-                    {
-                      "text": "to",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 3
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "λυτρόω",
-                  "morph": "Gr,VTSAM3,,S,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G30840",
-                  "content": "λυτρώσηται",
-                  "children": [
-                    {
-                      "text": "redeem",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "ἐγώ",
-                  "morph": "Gr,RP,,,1A,P,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G14730",
-                  "content": "ἡμᾶς",
-                  "children": [
-                    {
-                      "text": "us",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 2,
-                      "occurrences": 2
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "ἀπό",
-                  "morph": "Gr,P,,,,,G,,,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G05750",
-                  "content": "ἀπὸ",
-                  "children": [
-                    {
-                      "text": "from",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "πᾶς",
-                  "morph": "Gr,EQ,,,,GFS,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G39560",
-                  "content": "πάσης",
-                  "children": [
-                    {
-                      "text": "all",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "ἀνομία",
-                  "morph": "Gr,N,,,,,GFS,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G04580",
-                  "content": "ἀνομίας",
-                  "children": [
-                    {
-                      "text": "lawlessness",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "καί",
-                  "morph": "Gr,CC,,,,,,,,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G25320",
-                  "content": "καὶ",
-                  "children": [
-                    {
-                      "text": "and",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "καθαρίζω",
-                  "morph": "Gr,VTSAA3,,S,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G25110",
-                  "content": "καθαρίσῃ",
-                  "children": [
-                    {
-                      "text": "to",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 2,
-                      "occurrences": 3
-                    },
-                    {
-                      "text": "make",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    },
-                    {
-                      "text": "pure",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "type": "text",
-                  "text": ","
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "ἑαυτοῦ",
-                  "morph": "Gr,RE,,,3DMS,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G14380",
-                  "content": "ἑαυτῷ",
-                  "children": [
-                    {
-                      "text": "for",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 2,
-                      "occurrences": 2
-                    },
-                    {
-                      "text": "himself",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 2,
-                      "occurrences": 2
-                    }
-                  ]
-                },
-                {
-                  "type": "text",
-                  "text": ","
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "λαός",
-                  "morph": "Gr,N,,,,,AMS,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G29920",
-                  "content": "λαὸν",
-                  "children": [
-                    {
-                      "text": "a",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "περιούσιος",
-                  "morph": "Gr,AA,,,,AMS,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G40410",
-                  "content": "περιούσιον",
-                  "children": [
-                    {
-                      "text": "special",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "λαός",
-                  "morph": "Gr,N,,,,,AMS,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G29920",
-                  "content": "λαὸν",
-                  "children": [
-                    {
-                      "text": "people",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "ζηλωτής",
-                  "morph": "Gr,N,,,,,AMS,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G22070",
-                  "content": "ζηλωτὴν",
-                  "children": [
-                    {
-                      "text": "who",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    },
-                    {
-                      "text": "are",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    },
-                    {
-                      "text": "eager",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    },
-                    {
-                      "text": "to",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 3,
-                      "occurrences": 3
-                    },
-                    {
-                      "text": "do",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "καλός",
-                  "morph": "Gr,AA,,,,GNP,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G25700",
-                  "content": "καλῶν",
-                  "children": [
-                    {
-                      "text": "good",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "ἔργον",
-                  "morph": "Gr,N,,,,,GNP,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G20410",
-                  "content": "ἔργων",
-                  "children": [
-                    {
-                      "text": "works",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "type": "text",
-                  "text": ". \n"
-                }
-              ]
-            },
-            "15": {
-              "verseObjects": [
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "λαλέω",
-                  "morph": "Gr,VTMPA2,,S,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G29800",
-                  "content": "λάλει",
-                  "children": [
-                    {
-                      "text": "Speak",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "οὗτος",
-                  "morph": "Gr,RD,,,,ANP,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G37780",
-                  "content": "ταῦτα",
-                  "children": [
-                    {
-                      "text": "of",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    },
-                    {
-                      "text": "these",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    },
-                    {
-                      "text": "things",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "type": "text",
-                  "text": ","
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "καί",
-                  "morph": "Gr,CC,,,,,,,,",
-                  "occurrence": 1,
-                  "occurrences": 2,
-                  "strong": "G25320",
-                  "content": "καὶ",
-                  "children": [
-                    {
-                      "tag": "zaln",
-                      "type": "milestone",
-                      "lemma": "παρακαλέω",
-                      "morph": "Gr,VIMPA2,,S,",
-                      "occurrence": 1,
-                      "occurrences": 1,
-                      "strong": "G38700",
-                      "content": "παρακάλει",
-                      "children": [
-                        {
-                          "text": "encourage",
-                          "tag": "w",
-                          "type": "word",
-                          "occurrence": 1,
-                          "occurrences": 1
-                        },
-                        {
-                          "text": "people",
-                          "tag": "w",
-                          "type": "word",
-                          "occurrence": 1,
-                          "occurrences": 1
-                        },
-                        {
-                          "text": "to",
-                          "tag": "w",
-                          "type": "word",
-                          "occurrence": 1,
-                          "occurrences": 1
-                        },
-                        {
-                          "text": "do",
-                          "tag": "w",
-                          "type": "word",
-                          "occurrence": 1,
-                          "occurrences": 1
-                        },
-                        {
-                          "text": "them",
-                          "tag": "w",
-                          "type": "word",
-                          "occurrence": 1,
-                          "occurrences": 1
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "type": "text",
-                  "text": ","
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "καί",
-                  "morph": "Gr,CC,,,,,,,,",
-                  "occurrence": 2,
-                  "occurrences": 2,
-                  "strong": "G25320",
-                  "content": "καὶ",
-                  "children": [
-                    {
-                      "text": "and",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "ἐλέγχω",
-                  "morph": "Gr,VIMPA2,,S,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G16510",
-                  "content": "ἔλεγχε",
-                  "children": [
-                    {
-                      "text": "give",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    },
-                    {
-                      "text": "correction",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "μετά",
-                  "morph": "Gr,P,,,,,G,,,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G33260",
-                  "content": "μετὰ",
-                  "children": [
-                    {
-                      "text": "with",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "πᾶς",
-                  "morph": "Gr,EQ,,,,GFS,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G39560",
-                  "content": "πάσης",
-                  "children": [
-                    {
-                      "text": "all",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "ἐπιταγή",
-                  "morph": "Gr,N,,,,,GFS,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G20030",
-                  "content": "ἐπιταγῆς",
-                  "children": [
-                    {
-                      "text": "authority",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "type": "text",
-                  "text": "."
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "περιφρονέω",
-                  "morph": "Gr,VTMPA3,,S,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G40650",
-                  "content": "περιφρονείτω",
-                  "children": [
-                    {
-                      "text": "Let",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "μηδείς",
-                  "morph": "Gr,RI,,,,NMS,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G33670",
-                  "content": "μηδείς",
-                  "children": [
-                    {
-                      "text": "no",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    },
-                    {
-                      "text": "one",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "περιφρονέω",
-                  "morph": "Gr,VTMPA3,,S,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G40650",
-                  "content": "περιφρονείτω",
-                  "children": [
-                    {
-                      "text": "disregard",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "tag": "zaln",
-                  "type": "milestone",
-                  "lemma": "σύ",
-                  "morph": "Gr,RP,,,2G,S,",
-                  "occurrence": 1,
-                  "occurrences": 1,
-                  "strong": "G47710",
-                  "content": "σου",
-                  "children": [
-                    {
-                      "text": "you",
-                      "tag": "w",
-                      "type": "word",
-                      "occurrence": 1,
-                      "occurrences": 1
-                    }
-                  ]
-                },
-                {
-                  "type": "text",
-                  "text": ".\n"
-                }
-              ]
-            }
-          },
-          "manifest": {
-            "language_id": "en",
-            "language_name": "English",
-            "direction": "ltr",
-            "subject": "Bible",
-            "resource_id": "ult",
-            "resource_title": "unfoldingWord Literal Text",
-            "description": "Gateway Language"
-          }
-        }
-      },
-      "targetLanguage": {
+  "bibles": {
+    "en": {
+      "ust": {
         "2": {
-          "1": "Kono ewe, oambe ziyenderera ne ntaero zisepahara. ",
-          "2": "Bakwame bakuru baswanera kuba no buiswaro, kuki kutika, ne nkutwisiso, nentumero irukite, ne rato ne tundamo.",
-          "3": "Abakentu bakulwana nabo nji nto iswana baswanera kubona kuti nako yonshe ba kikutika, kali kushebeka. Kaba swaneli kunywa caha bujwara. Baswanera kuruta zirotu asf",
-          "4": "kuti  abakazana bazyibe kuha erato ke nkutwisiso ku bakwame babo ne bana bo. ",
-          "5": "Baswanera kuba ruta ku shuwisisa, kucena ko kuki babarera, no kubabarera marapa abo, no kukutika abakwame babo. Baswanezi kutenda ezi zintu ye ezywi lya Nyambe lya shauliwa.",
-          "6": "Kenjira iswana mu ereze banenu be cikwame babe ne nkutwisiso. ",
-          "7": "Muzonshe, muhare ko mutara omisebezi mirotu, hape entuto yenu isunde kucena ne kute. ",
-          "8": "Oambe eñusa ligorete lyazya mafosisa kuti enshe ozyo arwisa aswabe, kakuli kali kawane chimango cho kuamba.",
-          "9": "Abatanga ba swanezi kuki bika kwinshi yi banfumu babo muzintu zonshe. Baba tabise kali kuba kakana. ",
-          "10": "Bashahibi. Kono, basunde entumero yonshe ndotu, kuti yee muzintu zonshe bakutike entuto yetu ya Nyambe mupulusi wetu.",
-          "11": "Kakuli echishemo cha Nyambe cha bonahali ku bantu bonshe. ",
-          "12": "Chitu ruta okukana bumango ne ntakazo zefasi. Chitu ruta okuhara ke kutwisiso, ko kucena, mane ni ke chirumeli moinu nako, ",
-          "13": "netu lindire okutambura ensepo yetu ifuyaulitwe, kusunda okucena kwa Nyambe wetu omunene ne mupulusi Jesu Kireste.",
-          "14": "Jesu nakiha yemwini kwetu ko kutu rukurura kuzintu zonshe zaazya murao, noku cenesa, kebaka lyakwe, abantu bobutokwa aba kitakaleza kutenda misebezi mirotu.",
-          "15": "Ambe no kususueza kezi zintu. Usikulure ke manta onshe. Kwashabi ozyo akana kuku shuwa.",
-          "-1": "Kubatuka 2"
+          "1": "But you, Titus, you must teach the things that help people believe the truth about God.",
+          "2": "The older men should control themselves all the time. They should live in a way that other people respect, and they should speak wisely. They should also believe the true things about God, love others truly, and continuously do these things.",
+          "3": "The older women, like the men, should live so that everyone knows that they respect God very much. They must not say bad things about other people, and they must not drink very much wine. But they should teach others what is good.",
+          "4": "In this way, they should teach the younger women to think wisely and to love their own husbands and children.",
+          "5": "The older women should also teach the younger women to think good thoughts, not to act in a bad way toward any man, to work well at home, and to do what their husbands tell them. They should do all these things so that no one will mock God's word.",
+          "6": "And concerning the younger men, teach them, too. Tell them to control themselves well.",
+          "7": "As for you, Titus my son, always show other people how to do good deeds. In what you teach show the believers what is true and also show them how serious you are about your work.",
+          "8": "Teach people in a way that no one can criticize, so that if anybody wants to stop you, other people will shame them because they really have nothing bad to say about any of us.",
+          "9": "About our brothers and their families who are slaves: They should always submit to their masters. As much as possible, they should live in a way that pleases their masters in every way, and are they should not argue with them.",
+          "10": "They must not steal even little things from their masters; instead, they should be faithful to them, and they should do everything in a way that leads people to admire all that we teach about God, who saves us.",
+          "11": "Titus, all that I have written adds up to this: Everyone is now able to know that God wishes to save them; this is his gift to them.",
+          "12": "This saving grace from God trains us, as if we were children, to say no to the desires that are found in this world. It helps us to think about things in the right way, to be honest, truthful, and fair to other people and to always keep God in our thoughts and actions while we live in this world.",
+          "13": "At the same time, God teaches us to wait for what he will certainly do in the future, which is something that will make us very happy: That is, Jesus the Messiah, our Savior and powerful God, will return to us in great splendor.",
+          "14": "He gave himself to die as the payment to free us from our lawless nature, to make us his cherished possession, a treasured people that he has made clean, a people whose greatest joy is to do what is good.",
+          "15": "Titus, speak about these things. Urge those who hear you to live as I have described. And use your full right of command to correct our brothers and sisters when it is necessary. Let no one disregard what you say."
         },
         "manifest": {
-          "language_id": "fwe",
-          "language_name": "Fwe",
+          "language_id": "en",
+          "language_name": "English",
           "direction": "ltr",
           "subject": "Bible",
-          "resource_id": "targetLanguage",
-          "resource_title": "",
-          "description": "Target Language"
+          "resource_id": "ust",
+          "resource_title": "unfoldingWord Simplified Text",
+          "description": "Gateway Language"
+        }
+      },
+      "ult": {
+        "2": {
+          "1": {
+            "verseObjects": [
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "δέ",
+                "morph": "Gr,CC,,,,,,,,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G11610",
+                "content": "δὲ",
+                "children": [
+                  {
+                    "text": "But",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "σύ",
+                "morph": "Gr,RP,,,2N,S,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G47710",
+                "content": "σὺ",
+                "children": [
+                  {
+                    "text": "you",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "type": "text",
+                "text": ","
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "λαλέω",
+                "morph": "Gr,VTMPA2,,S,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G29800",
+                "content": "λάλει",
+                "children": [
+                  {
+                    "text": "speak",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "ὅς",
+                "morph": "Gr,RD,,,,ANP,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G37390",
+                "content": "ἃ",
+                "children": [
+                  {
+                    "text": "what",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "πρέπω",
+                "morph": "Gr,VIIPA3,,S,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G42410",
+                "content": "πρέπει",
+                "children": [
+                  {
+                    "text": "fits",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "ὁ",
+                "morph": "Gr,RD,,,,DFS,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G35880",
+                "content": "τῇ",
+                "children": [
+                  {
+                    "text": "with",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "ὑγιαίνω",
+                "morph": "Gr,VIPPA,DFS,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G51980",
+                "content": "ὑγιαινούσῃ",
+                "children": [
+                  {
+                    "text": "faithful",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "διδασκαλία",
+                "morph": "Gr,N,,,,,DFS,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G13190",
+                "content": "διδασκαλίᾳ",
+                "children": [
+                  {
+                    "text": "instruction",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "type": "text",
+                "text": ". \n"
+              }
+            ]
+          },
+          "2": {
+            "verseObjects": [
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "πρεσβύτης",
+                "morph": "Gr,N,,,,,AMP,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G42460",
+                "content": "πρεσβύτας",
+                "children": [
+                  {
+                    "text": "Teach",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  },
+                  {
+                    "text": "older",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  },
+                  {
+                    "text": "men",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "εἰμί",
+                "morph": "Gr,VLNPA,,,,,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G15100",
+                "content": "εἶναι",
+                "children": [
+                  {
+                    "text": "to",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  },
+                  {
+                    "text": "be",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "νηφάλιος",
+                "morph": "Gr,NS,,,,AMP,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G35240",
+                "content": "νηφαλίους",
+                "children": [
+                  {
+                    "text": "temperate",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "type": "text",
+                "text": ","
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "σεμνός",
+                "morph": "Gr,NP,,,,AMP,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G45860",
+                "content": "σεμνούς",
+                "children": [
+                  {
+                    "text": "dignified",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "type": "text",
+                "text": ","
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "σώφρων",
+                "morph": "Gr,NS,,,,AMP,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G49980",
+                "content": "σώφρονας",
+                "children": [
+                  {
+                    "text": "sensible",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "type": "text",
+                "text": ","
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "ὑγιαίνω",
+                "morph": "Gr,VIPPA,AMP,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G51980",
+                "content": "ὑγιαίνοντας",
+                "children": [
+                  {
+                    "text": "sound",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "ὁ",
+                "morph": "Gr,EA,,,,DFS,",
+                "occurrence": 3,
+                "occurrences": 3,
+                "strong": "G35880",
+                "content": "τῇ",
+                "children": [
+                  {
+                    "text": "in",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 3
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "πίστις",
+                "morph": "Gr,N,,,,,DFS,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G41020",
+                "content": "πίστει",
+                "children": [
+                  {
+                    "text": "faith",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "type": "text",
+                "text": ","
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "ὁ",
+                "morph": "Gr,EA,,,,DFS,",
+                "occurrence": 2,
+                "occurrences": 3,
+                "strong": "G35880",
+                "content": "τῇ",
+                "children": [
+                  {
+                    "text": "in",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 2,
+                    "occurrences": 3
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "ἀγάπη",
+                "morph": "Gr,N,,,,,DFS,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G00260",
+                "content": "ἀγάπῃ",
+                "children": [
+                  {
+                    "text": "love",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "type": "text",
+                "text": ","
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "ὁ",
+                "morph": "Gr,EA,,,,DFS,",
+                "occurrence": 3,
+                "occurrences": 3,
+                "strong": "G35880",
+                "content": "τῇ",
+                "children": [
+                  {
+                    "text": "and",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "ὁ",
+                "morph": "Gr,EA,,,,DFS,",
+                "occurrence": 1,
+                "occurrences": 3,
+                "strong": "G35880",
+                "content": "τῇ",
+                "children": [
+                  {
+                    "text": "in",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 3,
+                    "occurrences": 3
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "ὑπομονή",
+                "morph": "Gr,N,,,,,DFS,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G52810",
+                "content": "ὑπομονῇ",
+                "children": [
+                  {
+                    "text": "perseverance",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "type": "text",
+                "text": ". \n"
+              }
+            ]
+          },
+          "3": {
+            "verseObjects": [
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "πρεσβῦτις",
+                "morph": "Gr,N,,,,,AFP,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G42470",
+                "content": "πρεσβύτιδας",
+                "children": [
+                  {
+                    "text": "Teach",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  },
+                  {
+                    "text": "older",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  },
+                  {
+                    "text": "women",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "ὡσαύτως",
+                "morph": "Gr,D,,,,,,,,,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G56150",
+                "content": "ὡσαύτως",
+                "children": [
+                  {
+                    "text": "likewise",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "ἐν",
+                "morph": "Gr,P,,,,,D,,,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G17220",
+                "content": "ἐν",
+                "children": [
+                  {
+                    "text": "to",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 3
+                  },
+                  {
+                    "text": "be",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 2
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "ἱεροπρεπής",
+                "morph": "Gr,NS,,,,AFP,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G24120",
+                "content": "ἱεροπρεπεῖς",
+                "children": [
+                  {
+                    "text": "reverent",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "πολλός",
+                "morph": "Gr,EQ,,,,DMS,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G41830",
+                "content": "πολλῷ",
+                "children": [
+                  {
+                    "text": "in",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "κατάστημα",
+                "morph": "Gr,N,,,,,DNS,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G26880",
+                "content": "καταστήματι",
+                "children": [
+                  {
+                    "text": "behavior",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "type": "text",
+                "text": ","
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "μή",
+                "morph": "Gr,D,,,,,,,,,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G33610",
+                "content": "μὴ",
+                "children": [
+                  {
+                    "text": "not",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "διάβολος",
+                "morph": "Gr,NS,,,,AFP,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G12280",
+                "content": "διαβόλους",
+                "children": [
+                  {
+                    "text": "slanderers",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "μηδέ",
+                "morph": "Gr,D,,,,,,,,,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G33660",
+                "content": "μηδὲ",
+                "children": [
+                  {
+                    "text": "or",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "δουλόω",
+                "morph": "Gr,VIPEP,AFP,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G14020",
+                "content": "δεδουλωμένας",
+                "children": [
+                  {
+                    "text": "being",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  },
+                  {
+                    "text": "slaves",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  },
+                  {
+                    "text": "to",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 2,
+                    "occurrences": 3
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "πολλός",
+                "morph": "Gr,EQ,,,,DMS,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G41830",
+                "content": "πολλῷ",
+                "children": [
+                  {
+                    "text": "much",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "οἶνος",
+                "morph": "Gr,N,,,,,DMS,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G36310",
+                "content": "οἴνῳ",
+                "children": [
+                  {
+                    "text": "wine",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "type": "text",
+                "text": ","
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "καλοδιδάσκαλος",
+                "morph": "Gr,NS,,,,AFP,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G25670",
+                "content": "καλοδιδασκάλους",
+                "children": [
+                  {
+                    "text": "but",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "διάβολος",
+                "morph": "Gr,NS,,,,AFP,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G12280",
+                "content": "διαβόλους",
+                "children": [
+                  {
+                    "text": "to",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 3,
+                    "occurrences": 3
+                  },
+                  {
+                    "text": "be",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 2,
+                    "occurrences": 2
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "καλοδιδάσκαλος",
+                "morph": "Gr,NS,,,,AFP,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G25670",
+                "content": "καλοδιδασκάλους",
+                "children": [
+                  {
+                    "text": "teachers",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  },
+                  {
+                    "text": "of",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  },
+                  {
+                    "text": "what",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  },
+                  {
+                    "text": "is",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  },
+                  {
+                    "text": "good",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "type": "text",
+                "text": ". \n"
+              }
+            ]
+          },
+          "4": {
+            "verseObjects": [
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "ἵνα",
+                "morph": "Gr,CS,,,,,,,,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G24430",
+                "content": "ἵνα",
+                "children": [
+                  {
+                    "text": "In",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  },
+                  {
+                    "text": "this",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  },
+                  {
+                    "text": "way",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "σωφρονίζω",
+                "morph": "Gr,VTSPA3,,P,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G49940",
+                "content": "σωφρονίζωσι",
+                "children": [
+                  {
+                    "text": "they",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  },
+                  {
+                    "text": "may",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  },
+                  {
+                    "text": "train",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "ὁ",
+                "morph": "Gr,EA,,,,AFP,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G35880",
+                "content": "τὰς",
+                "children": [
+                  {
+                    "text": "the",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "νέος",
+                "morph": "Gr,NS,,,,AFP,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G35010",
+                "content": "νέας",
+                "children": [
+                  {
+                    "text": "younger",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  },
+                  {
+                    "text": "women",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "εἰμί",
+                "morph": "Gr,VLNPA,,,,,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G15100",
+                "content": "εἶναι",
+                "children": [
+                  {
+                    "text": "to",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "φίλανδρος",
+                "morph": "Gr,NS,,,,AFP,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G53620",
+                "content": "φιλάνδρους",
+                "children": [
+                  {
+                    "text": "love",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  },
+                  {
+                    "text": "their",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  },
+                  {
+                    "text": "own",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  },
+                  {
+                    "text": "husbands",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "φιλότεκνος",
+                "morph": "Gr,NS,,,,AFP,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G53880",
+                "content": "φιλοτέκνους",
+                "children": [
+                  {
+                    "text": "and",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  },
+                  {
+                    "text": "children",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "type": "text",
+                "text": ", \n"
+              }
+            ]
+          },
+          "5": {
+            "verseObjects": [
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "σώφρων",
+                "morph": "Gr,NS,,,,AFP,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G49980",
+                "content": "σώφρονας",
+                "children": [
+                  {
+                    "text": "to",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 2
+                  },
+                  {
+                    "text": "be",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 2
+                  },
+                  {
+                    "text": "sensible",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "type": "text",
+                "text": ","
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "ἁγνός",
+                "morph": "Gr,NS,,,,AFP,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G00530",
+                "content": "ἁγνάς",
+                "children": [
+                  {
+                    "text": "pure",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "type": "text",
+                "text": ","
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "ἀγαθός",
+                "morph": "Gr,NS,,,,AFP,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G00180",
+                "content": "ἀγαθάς",
+                "children": [
+                  {
+                    "text": "good",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "οἰκουργός",
+                "morph": "Gr,NS,,,,AFP,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G36260",
+                "content": "οἰκουργούς",
+                "children": [
+                  {
+                    "text": "housekeepers",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "type": "text",
+                "text": ","
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "ὑποτάσσω",
+                "morph": "Gr,VIPPP,AFP,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G52930",
+                "content": "ὑποτασσομένας",
+                "children": [
+                  {
+                    "text": "and",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  },
+                  {
+                    "text": "obedient",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "ὁ",
+                "morph": "Gr,EP,,,,DMP,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G35880",
+                "content": "τοῖς",
+                "children": [
+                  {
+                    "text": "to",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 2,
+                    "occurrences": 2
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "ἴδιος",
+                "morph": "Gr,EF,,,,DMP,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G23980",
+                "content": "ἰδίοις",
+                "children": [
+                  {
+                    "text": "their",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  },
+                  {
+                    "text": "own",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "ἀνήρ",
+                "morph": "Gr,N,,,,,DMP,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G04350",
+                "content": "ἀνδράσιν",
+                "children": [
+                  {
+                    "text": "husbands",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "type": "text",
+                "text": ","
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "ἵνα",
+                "morph": "Gr,CS,,,,,,,,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G24430",
+                "content": "ἵνα",
+                "children": [
+                  {
+                    "text": "so",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  },
+                  {
+                    "text": "that",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "ὁ",
+                "morph": "Gr,EA,,,,GMS,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G35880",
+                "content": "τοῦ",
+                "children": [
+                  {
+                    "tag": "zaln",
+                    "type": "milestone",
+                    "lemma": "θεός",
+                    "morph": "Gr,N,,,,,GMS,",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "strong": "G23160",
+                    "content": "Θεοῦ",
+                    "children": [
+                      {
+                        "text": "God",
+                        "tag": "w",
+                        "type": "word",
+                        "occurrence": 1,
+                        "occurrences": 1
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "text",
+                "text": "'"
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "ὁ",
+                "morph": "Gr,EA,,,,GMS,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G35880",
+                "content": "τοῦ",
+                "children": [
+                  {
+                    "tag": "zaln",
+                    "type": "milestone",
+                    "lemma": "θεός",
+                    "morph": "Gr,N,,,,,GMS,",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "strong": "G23160",
+                    "content": "Θεοῦ",
+                    "children": [
+                      {
+                        "text": "s",
+                        "tag": "w",
+                        "type": "word",
+                        "occurrence": 1,
+                        "occurrences": 1
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "ὁ",
+                "morph": "Gr,EA,,,,NMS,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G35880",
+                "content": "ὁ",
+                "children": [
+                  {
+                    "tag": "zaln",
+                    "type": "milestone",
+                    "lemma": "λόγος",
+                    "morph": "Gr,N,,,,,NMS,",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "strong": "G30560",
+                    "content": "λόγος",
+                    "children": [
+                      {
+                        "text": "word",
+                        "tag": "w",
+                        "type": "word",
+                        "occurrence": 1,
+                        "occurrences": 1
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "μή",
+                "morph": "Gr,D,,,,,,,,,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G33610",
+                "content": "μὴ",
+                "children": [
+                  {
+                    "text": "may",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  },
+                  {
+                    "text": "not",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "βλασφημέω",
+                "morph": "Gr,VISPP3,,S,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G09870",
+                "content": "βλασφημῆται",
+                "children": [
+                  {
+                    "text": "be",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 2,
+                    "occurrences": 2
+                  },
+                  {
+                    "text": "insulted",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "type": "text",
+                "text": ". \n"
+              }
+            ]
+          },
+          "6": {
+            "verseObjects": [
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "ὡσαύτως",
+                "morph": "Gr,D,,,,,,,,,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G56150",
+                "content": "ὡσαύτως",
+                "children": [
+                  {
+                    "text": "In",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "ὁ",
+                "morph": "Gr,EA,,,,AMP,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G35880",
+                "content": "τοὺς",
+                "children": [
+                  {
+                    "text": "the",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 2
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "ὡσαύτως",
+                "morph": "Gr,D,,,,,,,,,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G56150",
+                "content": "ὡσαύτως",
+                "children": [
+                  {
+                    "text": "same",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  },
+                  {
+                    "text": "way",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "type": "text",
+                "text": ","
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "παρακαλέω",
+                "morph": "Gr,VTMPA2,,S,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G38700",
+                "content": "παρακάλει",
+                "children": [
+                  {
+                    "text": "encourage",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "ὡσαύτως",
+                "morph": "Gr,D,,,,,,,,,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G56150",
+                "content": "ὡσαύτως",
+                "children": [
+                  {
+                    "text": "the",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 2,
+                    "occurrences": 2
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "νεώτερος",
+                "morph": "Gr,AA,,,,AMPC",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G35125",
+                "content": "νεωτέρους",
+                "children": [
+                  {
+                    "text": "younger",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  },
+                  {
+                    "text": "men",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "σωφρονέω",
+                "morph": "Gr,VINPA,,,,,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G49930",
+                "content": "σωφρονεῖν",
+                "children": [
+                  {
+                    "text": "to",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  },
+                  {
+                    "text": "use",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  },
+                  {
+                    "text": "good",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  },
+                  {
+                    "text": "sense",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "type": "text",
+                "text": ". \n"
+              }
+            ]
+          },
+          "7": {
+            "verseObjects": [
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "περί",
+                "morph": "Gr,P,,,,,A,,,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G40120",
+                "content": "περὶ",
+                "children": [
+                  {
+                    "text": "In",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 2
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "πᾶς",
+                "morph": "Gr,RI,,,,ANP,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G39560",
+                "content": "πάντα",
+                "children": [
+                  {
+                    "text": "all",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  },
+                  {
+                    "text": "ways",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "παρέχω",
+                "morph": "Gr,VTPPM,NMS,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G39300",
+                "content": "παρεχόμενος",
+                "children": [
+                  {
+                    "text": "present",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "σεαυτοῦ",
+                "morph": "Gr,RE,,,2AMS,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G45720",
+                "content": "σεαυτὸν",
+                "children": [
+                  {
+                    "text": "yourself",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "τύπος",
+                "morph": "Gr,N,,,,,AMS,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G51790",
+                "content": "τύπον",
+                "children": [
+                  {
+                    "text": "as",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  },
+                  {
+                    "text": "an",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  },
+                  {
+                    "text": "example",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "καλός",
+                "morph": "Gr,AA,,,,GNP,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G25700",
+                "content": "καλῶν",
+                "children": [
+                  {
+                    "text": "of",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  },
+                  {
+                    "text": "good",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "ἔργον",
+                "morph": "Gr,N,,,,,GNP,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G20410",
+                "content": "ἔργων",
+                "children": [
+                  {
+                    "text": "works",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "type": "text",
+                "text": "."
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "ἐν",
+                "morph": "Gr,P,,,,,D,,,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G17220",
+                "content": "ἐν",
+                "children": [
+                  {
+                    "text": "In",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 2,
+                    "occurrences": 2
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "ὁ",
+                "morph": "Gr,EP,,,,DFS,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G35880",
+                "content": "τῇ",
+                "children": [
+                  {
+                    "text": "your",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "διδασκαλία",
+                "morph": "Gr,N,,,,,DFS,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G13190",
+                "content": "διδασκαλίᾳ",
+                "children": [
+                  {
+                    "text": "teaching",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "type": "text",
+                "text": ","
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "ἀφθορία",
+                "morph": "Gr,N,,,,,AFS,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G08627",
+                "content": "ἀφθορίαν",
+                "children": [
+                  {
+                    "text": "show",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  },
+                  {
+                    "text": "integrity",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "type": "text",
+                "text": ","
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "σεμνότης",
+                "morph": "Gr,N,,,,,AFS,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G45870",
+                "content": "σεμνότητα",
+                "children": [
+                  {
+                    "text": "dignity",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "type": "text",
+                "text": ", \n"
+              }
+            ]
+          },
+          "8": {
+            "verseObjects": [
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "λόγος",
+                "morph": "Gr,N,,,,,AMS,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G30560",
+                "content": "λόγον",
+                "children": [
+                  {
+                    "text": "and",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  },
+                  {
+                    "text": "a",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "ὑγιής",
+                "morph": "Gr,AA,,,,AMS,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G51990",
+                "content": "ὑγιῆ",
+                "children": [
+                  {
+                    "text": "correct",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "λόγος",
+                "morph": "Gr,N,,,,,AMS,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G30560",
+                "content": "λόγον",
+                "children": [
+                  {
+                    "text": "message",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "ἀκατάγνωστος",
+                "morph": "Gr,NS,,,,AMS,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G01760",
+                "content": "ἀκατάγνωστον",
+                "children": [
+                  {
+                    "text": "that",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 2
+                  },
+                  {
+                    "text": "is",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  },
+                  {
+                    "text": "above",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  },
+                  {
+                    "text": "criticism",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "type": "text",
+                "text": ","
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "ἵνα",
+                "morph": "Gr,CS,,,,,,,,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G24430",
+                "content": "ἵνα",
+                "children": [
+                  {
+                    "text": "so",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  },
+                  {
+                    "text": "that",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 2,
+                    "occurrences": 2
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "ὁ",
+                "morph": "Gr,RD,,,,NMS,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G35880",
+                "content": "ὁ",
+                "children": [
+                  {
+                    "text": "anyone",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "ἐκ",
+                "morph": "Gr,P,,,,,G,,,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G15370",
+                "content": "ἐξ",
+                "children": [
+                  {
+                    "text": "who",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "ἐναντίος",
+                "morph": "Gr,NS,,,,GFS,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G17270",
+                "content": "ἐναντίας",
+                "children": [
+                  {
+                    "text": "opposes",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  },
+                  {
+                    "text": "you",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "ἐντρέπω",
+                "morph": "Gr,VISAP3,,S,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G17880",
+                "content": "ἐντραπῇ",
+                "children": [
+                  {
+                    "text": "may",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  },
+                  {
+                    "text": "be",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  },
+                  {
+                    "text": "ashamed",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "μηδείς",
+                "morph": "Gr,RI,,,,ANS,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G33670",
+                "content": "μηδὲν",
+                "children": [
+                  {
+                    "text": "because",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "ἔχω",
+                "morph": "Gr,VTPPA,NMS,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G21920",
+                "content": "ἔχων",
+                "children": [
+                  {
+                    "text": "they",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  },
+                  {
+                    "text": "have",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "μηδείς",
+                "morph": "Gr,RI,,,,ANS,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G33670",
+                "content": "μηδὲν",
+                "children": [
+                  {
+                    "text": "nothing",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "φαῦλος",
+                "morph": "Gr,NS,,,,ANS,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G53370",
+                "content": "φαῦλον",
+                "children": [
+                  {
+                    "text": "bad",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "λέγω",
+                "morph": "Gr,VTNPA,,,,,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G30040",
+                "content": "λέγειν",
+                "children": [
+                  {
+                    "text": "to",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  },
+                  {
+                    "text": "say",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "περί",
+                "morph": "Gr,P,,,,,G,,,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G40120",
+                "content": "περὶ",
+                "children": [
+                  {
+                    "text": "about",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "ἐγώ",
+                "morph": "Gr,RP,,,1G,P,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G14730",
+                "content": "ἡμῶν",
+                "children": [
+                  {
+                    "text": "us",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "type": "text",
+                "text": ". \n"
+              }
+            ]
+          },
+          "9": {
+            "verseObjects": [
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "δοῦλος",
+                "morph": "Gr,N,,,,,AMP,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G14010",
+                "content": "δούλους",
+                "children": [
+                  {
+                    "text": "Teach",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  },
+                  {
+                    "text": "slaves",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "εὐάρεστος",
+                "morph": "Gr,NP,,,,AMP,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G21010",
+                "content": "εὐαρέστους",
+                "children": [
+                  {
+                    "text": "to",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 2
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "ὑποτάσσω",
+                "morph": "Gr,VINPM,,,,,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G52930",
+                "content": "ὑποτάσσεσθαι",
+                "children": [
+                  {
+                    "text": "obey",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "ἴδιος",
+                "morph": "Gr,EF,,,,DMP,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G23980",
+                "content": "ἰδίοις",
+                "children": [
+                  {
+                    "text": "their",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "δεσπότης",
+                "morph": "Gr,N,,,,,DMP,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G12030",
+                "content": "δεσπόταις",
+                "children": [
+                  {
+                    "text": "masters",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "ἐν",
+                "morph": "Gr,P,,,,,D,,,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G17220",
+                "content": "ἐν",
+                "children": [
+                  {
+                    "text": "in",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "πᾶς",
+                "morph": "Gr,RI,,,,DNP,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G39560",
+                "content": "πᾶσιν",
+                "children": [
+                  {
+                    "text": "everything",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "type": "text",
+                "text": ","
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "ὑποτάσσω",
+                "morph": "Gr,VINPM,,,,,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G52930",
+                "content": "ὑποτάσσεσθαι",
+                "children": [
+                  {
+                    "text": "to",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 2,
+                    "occurrences": 2
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "εὐάρεστος",
+                "morph": "Gr,NP,,,,AMP,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G21010",
+                "content": "εὐαρέστους",
+                "children": [
+                  {
+                    "text": "please",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  },
+                  {
+                    "text": "them",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 2
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "εἰμί",
+                "morph": "Gr,VLNPA,,,,,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G15100",
+                "content": "εἶναι",
+                "children": [
+                  {
+                    "text": "and",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "μή",
+                "morph": "Gr,D,,,,,,,,,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G33610",
+                "content": "μὴ",
+                "children": [
+                  {
+                    "text": "not",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "ἀντιλέγω",
+                "morph": "Gr,VIPPA,AMP,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G04830",
+                "content": "ἀντιλέγοντας",
+                "children": [
+                  {
+                    "text": "argue",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  },
+                  {
+                    "text": "with",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  },
+                  {
+                    "text": "them",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 2,
+                    "occurrences": 2
+                  }
+                ]
+              },
+              {
+                "type": "text",
+                "text": ", \n"
+              }
+            ]
+          },
+          "10": {
+            "verseObjects": [
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "νοσφίζω",
+                "morph": "Gr,VIPPM,AMP,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G35570",
+                "content": "νοσφιζομένους",
+                "children": [
+                  {
+                    "text": "to",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 3
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "μή",
+                "morph": "Gr,D,,,,,,,,,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G33610",
+                "content": "μὴ",
+                "children": [
+                  {
+                    "text": "not",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "νοσφίζω",
+                "morph": "Gr,VIPPM,AMP,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G35570",
+                "content": "νοσφιζομένους",
+                "children": [
+                  {
+                    "text": "steal",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  },
+                  {
+                    "text": "from",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  },
+                  {
+                    "text": "them",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "type": "text",
+                "text": ","
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "ἀλλά",
+                "morph": "Gr,CC,,,,,,,,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G02350",
+                "content": "ἀλλὰ",
+                "children": [
+                  {
+                    "text": "but",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  },
+                  {
+                    "text": "instead",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "ἐνδείκνυμι",
+                "morph": "Gr,VTPPM,AMP,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G17310",
+                "content": "ἐνδεικνυμένους",
+                "children": [
+                  {
+                    "text": "to",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 2,
+                    "occurrences": 3
+                  },
+                  {
+                    "text": "demonstrate",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "πᾶς",
+                "morph": "Gr,EQ,,,,AFS,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G39560",
+                "content": "πᾶσαν",
+                "children": [
+                  {
+                    "text": "all",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "ἀγαθός",
+                "morph": "Gr,NS,,,,AFS,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G00180",
+                "content": "ἀγαθήν",
+                "children": [
+                  {
+                    "text": "good",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "πίστις",
+                "morph": "Gr,N,,,,,AFS,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G41020",
+                "content": "πίστιν",
+                "children": [
+                  {
+                    "text": "faith",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "type": "text",
+                "text": ","
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "ἵνα",
+                "morph": "Gr,CS,,,,,,,,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G24430",
+                "content": "ἵνα",
+                "children": [
+                  {
+                    "text": "so",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  },
+                  {
+                    "text": "that",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "ἐν",
+                "morph": "Gr,P,,,,,D,,,",
+                "occurrence": 1,
+                "occurrences": 2,
+                "strong": "G17220",
+                "content": "ἐν",
+                "children": [
+                  {
+                    "text": "in",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "πᾶς",
+                "morph": "Gr,RI,,,,DNP,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G39560",
+                "content": "πᾶσιν",
+                "children": [
+                  {
+                    "text": "every",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  },
+                  {
+                    "text": "way",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "κοσμέω",
+                "morph": "Gr,VTSPA3,,P,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G28850",
+                "content": "κοσμῶσιν",
+                "children": [
+                  {
+                    "text": "they",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  },
+                  {
+                    "text": "may",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  },
+                  {
+                    "text": "bring",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  },
+                  {
+                    "text": "credit",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "ὁ",
+                "morph": "Gr,EA,,,,AFS,",
+                "occurrence": 1,
+                "occurrences": 2,
+                "strong": "G35880",
+                "content": "τὴν",
+                "children": [
+                  {
+                    "text": "to",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 3,
+                    "occurrences": 3
+                  },
+                  {
+                    "text": "the",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "διδασκαλία",
+                "morph": "Gr,N,,,,,AFS,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G13190",
+                "content": "διδασκαλίαν",
+                "children": [
+                  {
+                    "text": "teaching",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "ὁ",
+                "morph": "Gr,RD,,,,AFS,",
+                "occurrence": 2,
+                "occurrences": 2,
+                "strong": "G35880",
+                "content": "τὴν",
+                "children": [
+                  {
+                    "text": "about",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "θεός",
+                "morph": "Gr,N,,,,,GMS,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G23160",
+                "content": "Θεοῦ",
+                "children": [
+                  {
+                    "text": "God",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "ἐγώ",
+                "morph": "Gr,RP,,,1G,P,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G14730",
+                "content": "ἡμῶν",
+                "children": [
+                  {
+                    "text": "our",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "ὁ",
+                "morph": "Gr,EA,,,,GMS,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G35880",
+                "content": "τοῦ",
+                "children": [
+                  {
+                    "tag": "zaln",
+                    "type": "milestone",
+                    "lemma": "σωτήρ",
+                    "morph": "Gr,N,,,,,GMS,",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "strong": "G49900",
+                    "content": "Σωτῆρος",
+                    "children": [
+                      {
+                        "text": "Savior",
+                        "tag": "w",
+                        "type": "word",
+                        "occurrence": 1,
+                        "occurrences": 1
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "text",
+                "text": ". \n"
+              }
+            ]
+          },
+          "11": {
+            "verseObjects": [
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "γάρ",
+                "morph": "Gr,CC,,,,,,,,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G10630",
+                "content": "γὰρ",
+                "children": [
+                  {
+                    "text": "For",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "ὁ",
+                "morph": "Gr,EA,,,,NFS,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G35880",
+                "content": "ἡ",
+                "children": [
+                  {
+                    "text": "the",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 2
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "χάρις",
+                "morph": "Gr,N,,,,,NFS,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G54850",
+                "content": "χάρις",
+                "children": [
+                  {
+                    "text": "grace",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "ὁ",
+                "morph": "Gr,EA,,,,GMS,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G35880",
+                "content": "τοῦ",
+                "children": [
+                  {
+                    "tag": "zaln",
+                    "type": "milestone",
+                    "lemma": "θεός",
+                    "morph": "Gr,N,,,,,GMS,",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "strong": "G23160",
+                    "content": "Θεοῦ",
+                    "children": [
+                      {
+                        "text": "of",
+                        "tag": "w",
+                        "type": "word",
+                        "occurrence": 1,
+                        "occurrences": 2
+                      },
+                      {
+                        "text": "God",
+                        "tag": "w",
+                        "type": "word",
+                        "occurrence": 1,
+                        "occurrences": 1
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "ἐπιφαίνω",
+                "morph": "Gr,VIIAP3,,S,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G20140",
+                "content": "ἐπεφάνη",
+                "children": [
+                  {
+                    "text": "has",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  },
+                  {
+                    "text": "appeared",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "σωτήριος",
+                "morph": "Gr,NS,,,,NMS,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G49920",
+                "content": "σωτήριος",
+                "children": [
+                  {
+                    "text": "for",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  },
+                  {
+                    "text": "the",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 2,
+                    "occurrences": 2
+                  },
+                  {
+                    "text": "salvation",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "πᾶς",
+                "morph": "Gr,EQ,,,,DMP,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G39560",
+                "content": "πᾶσιν",
+                "children": [
+                  {
+                    "text": "of",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 2,
+                    "occurrences": 2
+                  },
+                  {
+                    "text": "all",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "ἄνθρωπος",
+                "morph": "Gr,N,,,,,DMP,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G04440",
+                "content": "ἀνθρώποις",
+                "children": [
+                  {
+                    "text": "people",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "type": "text",
+                "text": ". \n"
+              }
+            ]
+          },
+          "12": {
+            "verseObjects": [
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "παιδεύω",
+                "morph": "Gr,VTPPA,NFS,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G38110",
+                "content": "παιδεύουσα",
+                "children": [
+                  {
+                    "text": "It",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  },
+                  {
+                    "text": "trains",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "ἐγώ",
+                "morph": "Gr,RP,,,1A,P,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G14730",
+                "content": "ἡμᾶς",
+                "children": [
+                  {
+                    "text": "us",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "ἵνα",
+                "morph": "Gr,CS,,,,,,,,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G24430",
+                "content": "ἵνα",
+                "children": [
+                  {
+                    "text": "to",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 2
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "ἀρνέομαι",
+                "morph": "Gr,VTPAM,NMP,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G07200",
+                "content": "ἀρνησάμενοι",
+                "children": [
+                  {
+                    "text": "reject",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "ὁ",
+                "morph": "Gr,EA,,,,AFS,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G35880",
+                "content": "τὴν",
+                "children": [
+                  {
+                    "tag": "zaln",
+                    "type": "milestone",
+                    "lemma": "ἀσέβεια",
+                    "morph": "Gr,N,,,,,AFS,",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "strong": "G07630",
+                    "content": "ἀσέβειαν",
+                    "children": [
+                      {
+                        "text": "godlessness",
+                        "tag": "w",
+                        "type": "word",
+                        "occurrence": 1,
+                        "occurrences": 1
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "καί",
+                "morph": "Gr,CC,,,,,,,,",
+                "occurrence": 3,
+                "occurrences": 3,
+                "strong": "G25320",
+                "content": "καὶ",
+                "children": [
+                  {
+                    "text": "and",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 3
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "ὁ",
+                "morph": "Gr,EA,,,,AFP,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G35880",
+                "content": "τὰς",
+                "children": [
+                  {
+                    "tag": "zaln",
+                    "type": "milestone",
+                    "lemma": "κοσμικός",
+                    "morph": "Gr,AA,,,,AFP,",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "strong": "G28860",
+                    "content": "κοσμικὰς",
+                    "children": [
+                      {
+                        "text": "worldly",
+                        "tag": "w",
+                        "type": "word",
+                        "occurrence": 1,
+                        "occurrences": 1
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "ἐπιθυμία",
+                "morph": "Gr,N,,,,,AFP,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G19390",
+                "content": "ἐπιθυμίας",
+                "children": [
+                  {
+                    "text": "passions",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "type": "text",
+                "text": ","
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "καί",
+                "morph": "Gr,CC,,,,,,,,",
+                "occurrence": 1,
+                "occurrences": 3,
+                "strong": "G25320",
+                "content": "καὶ",
+                "children": [
+                  {
+                    "text": "and",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 2,
+                    "occurrences": 3
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "σωφρόνως",
+                "morph": "Gr,D,,,,,,,,,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G49960",
+                "content": "σωφρόνως",
+                "children": [
+                  {
+                    "text": "to",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 2,
+                    "occurrences": 2
+                  },
+                  {
+                    "text": "live",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  },
+                  {
+                    "text": "self",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "type": "text",
+                "text": "-"
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "σωφρόνως",
+                "morph": "Gr,D,,,,,,,,,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G49960",
+                "content": "σωφρόνως",
+                "children": [
+                  {
+                    "text": "controlled",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "type": "text",
+                "text": ","
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "δικαίως",
+                "morph": "Gr,D,,,,,,,,,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G13460",
+                "content": "δικαίως",
+                "children": [
+                  {
+                    "text": "upright",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "type": "text",
+                "text": ","
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "καί",
+                "morph": "Gr,CC,,,,,,,,",
+                "occurrence": 2,
+                "occurrences": 3,
+                "strong": "G25320",
+                "content": "καὶ",
+                "children": [
+                  {
+                    "text": "and",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 3,
+                    "occurrences": 3
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "εὐσεβῶς",
+                "morph": "Gr,D,,,,,,,,,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G21530",
+                "content": "εὐσεβῶς",
+                "children": [
+                  {
+                    "text": "godly",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "ζάω",
+                "morph": "Gr,VISAA1,,P,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G21980",
+                "content": "ζήσωμεν",
+                "children": [
+                  {
+                    "text": "lives",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "ἐν",
+                "morph": "Gr,P,,,,,D,,,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G17220",
+                "content": "ἐν",
+                "children": [
+                  {
+                    "text": "in",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "ὁ",
+                "morph": "Gr,EA,,,,DMS,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G35880",
+                "content": "τῷ",
+                "children": [
+                  {
+                    "tag": "zaln",
+                    "type": "milestone",
+                    "lemma": "νῦν",
+                    "morph": "Gr,D,,,,,,,,,",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "strong": "G35680",
+                    "content": "νῦν",
+                    "children": [
+                      {
+                        "text": "this",
+                        "tag": "w",
+                        "type": "word",
+                        "occurrence": 1,
+                        "occurrences": 1
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "αἰών",
+                "morph": "Gr,N,,,,,DMS,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G01650",
+                "content": "αἰῶνι",
+                "children": [
+                  {
+                    "text": "age",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "type": "text",
+                "text": ", \n"
+              }
+            ]
+          },
+          "13": {
+            "verseObjects": [
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "προσδέχομαι",
+                "morph": "Gr,VTPPM,NMP,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G43270",
+                "content": "προσδεχόμενοι",
+                "children": [
+                  {
+                    "text": "while",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  },
+                  {
+                    "text": "we",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  },
+                  {
+                    "text": "look",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  },
+                  {
+                    "text": "forward",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  },
+                  {
+                    "text": "to",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  },
+                  {
+                    "text": "receiving",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "ὁ",
+                "morph": "Gr,EA,,,,AFS,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G35880",
+                "content": "τὴν",
+                "children": [
+                  {
+                    "text": "our",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 2
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "μακάριος",
+                "morph": "Gr,AA,,,,AFS,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G31070",
+                "content": "μακαρίαν",
+                "children": [
+                  {
+                    "text": "blessed",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "ἐλπίς",
+                "morph": "Gr,N,,,,,AFS,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G16800",
+                "content": "ἐλπίδα",
+                "children": [
+                  {
+                    "text": "hope",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "type": "text",
+                "text": ","
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "καί",
+                "morph": "Gr,CC,,,,,,,,",
+                "occurrence": 1,
+                "occurrences": 2,
+                "strong": "G25320",
+                "content": "καὶ",
+                "children": [
+                  {
+                    "tag": "zaln",
+                    "type": "milestone",
+                    "lemma": "ἐπιφάνεια",
+                    "morph": "Gr,N,,,,,AFS,",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "strong": "G20150",
+                    "content": "ἐπιφάνειαν",
+                    "children": [
+                      {
+                        "text": "the",
+                        "tag": "w",
+                        "type": "word",
+                        "occurrence": 1,
+                        "occurrences": 2
+                      },
+                      {
+                        "text": "appearance",
+                        "tag": "w",
+                        "type": "word",
+                        "occurrence": 1,
+                        "occurrences": 1
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "ὁ",
+                "morph": "Gr,EA,,,,GFS,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G35880",
+                "content": "τῆς",
+                "children": [
+                  {
+                    "text": "of",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 2
+                  },
+                  {
+                    "text": "the",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 2,
+                    "occurrences": 2
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "δόξα",
+                "morph": "Gr,N,,,,,GFS,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G13910",
+                "content": "δόξης",
+                "children": [
+                  {
+                    "text": "glory",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "ὁ",
+                "morph": "Gr,EA,,,,GMS,",
+                "occurrence": 1,
+                "occurrences": 2,
+                "strong": "G35880",
+                "content": "τοῦ",
+                "children": [
+                  {
+                    "text": "of",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 2,
+                    "occurrences": 2
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "ἐγώ",
+                "morph": "Gr,RP,,,1G,P,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G14730",
+                "content": "ἡμῶν",
+                "children": [
+                  {
+                    "text": "our",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 2,
+                    "occurrences": 2
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "μέγας",
+                "morph": "Gr,AA,,,,GMS,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G31730",
+                "content": "μεγάλου",
+                "children": [
+                  {
+                    "text": "great",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "θεός",
+                "morph": "Gr,N,,,,,GMS,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G23160",
+                "content": "Θεοῦ",
+                "children": [
+                  {
+                    "text": "God",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "καί",
+                "morph": "Gr,CC,,,,,,,,",
+                "occurrence": 2,
+                "occurrences": 2,
+                "strong": "G25320",
+                "content": "καὶ",
+                "children": [
+                  {
+                    "text": "and",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "σωτήρ",
+                "morph": "Gr,N,,,,,GMS,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G49900",
+                "content": "Σωτῆρος",
+                "children": [
+                  {
+                    "text": "Savior",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "Ἰησοῦς",
+                "morph": "Gr,N,,,,,GMS,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G24240",
+                "content": "Ἰησοῦ",
+                "children": [
+                  {
+                    "text": "Jesus",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "χριστός",
+                "morph": "Gr,N,,,,,GMS,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G55470",
+                "content": "Χριστοῦ",
+                "children": [
+                  {
+                    "text": "Christ",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "type": "text",
+                "text": ". \n"
+              }
+            ]
+          },
+          "14": {
+            "verseObjects": [
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "ὅς",
+                "morph": "Gr,RR,,,,NMS,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G37390",
+                "content": "ὃς",
+                "children": [
+                  {
+                    "text": "Jesus",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "δίδωμι",
+                "morph": "Gr,VTIAA3,,S,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G13250",
+                "content": "ἔδωκεν",
+                "children": [
+                  {
+                    "text": "gave",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "ἑαυτοῦ",
+                "morph": "Gr,RE,,,3AMS,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G14380",
+                "content": "ἑαυτὸν",
+                "children": [
+                  {
+                    "text": "himself",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 2
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "ὑπέρ",
+                "morph": "Gr,P,,,,,G,,,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G52280",
+                "content": "ὑπὲρ",
+                "children": [
+                  {
+                    "text": "for",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 2
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "ἐγώ",
+                "morph": "Gr,RP,,,1G,P,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G14730",
+                "content": "ἡμῶν",
+                "children": [
+                  {
+                    "text": "us",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 2
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "ἵνα",
+                "morph": "Gr,CS,,,,,,,,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G24430",
+                "content": "ἵνα",
+                "children": [
+                  {
+                    "text": "in",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  },
+                  {
+                    "text": "order",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  },
+                  {
+                    "text": "to",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 3
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "λυτρόω",
+                "morph": "Gr,VTSAM3,,S,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G30840",
+                "content": "λυτρώσηται",
+                "children": [
+                  {
+                    "text": "redeem",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "ἐγώ",
+                "morph": "Gr,RP,,,1A,P,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G14730",
+                "content": "ἡμᾶς",
+                "children": [
+                  {
+                    "text": "us",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 2,
+                    "occurrences": 2
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "ἀπό",
+                "morph": "Gr,P,,,,,G,,,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G05750",
+                "content": "ἀπὸ",
+                "children": [
+                  {
+                    "text": "from",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "πᾶς",
+                "morph": "Gr,EQ,,,,GFS,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G39560",
+                "content": "πάσης",
+                "children": [
+                  {
+                    "text": "all",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "ἀνομία",
+                "morph": "Gr,N,,,,,GFS,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G04580",
+                "content": "ἀνομίας",
+                "children": [
+                  {
+                    "text": "lawlessness",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "καί",
+                "morph": "Gr,CC,,,,,,,,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G25320",
+                "content": "καὶ",
+                "children": [
+                  {
+                    "text": "and",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "καθαρίζω",
+                "morph": "Gr,VTSAA3,,S,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G25110",
+                "content": "καθαρίσῃ",
+                "children": [
+                  {
+                    "text": "to",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 2,
+                    "occurrences": 3
+                  },
+                  {
+                    "text": "make",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  },
+                  {
+                    "text": "pure",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "type": "text",
+                "text": ","
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "ἑαυτοῦ",
+                "morph": "Gr,RE,,,3DMS,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G14380",
+                "content": "ἑαυτῷ",
+                "children": [
+                  {
+                    "text": "for",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 2,
+                    "occurrences": 2
+                  },
+                  {
+                    "text": "himself",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 2,
+                    "occurrences": 2
+                  }
+                ]
+              },
+              {
+                "type": "text",
+                "text": ","
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "λαός",
+                "morph": "Gr,N,,,,,AMS,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G29920",
+                "content": "λαὸν",
+                "children": [
+                  {
+                    "text": "a",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "περιούσιος",
+                "morph": "Gr,AA,,,,AMS,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G40410",
+                "content": "περιούσιον",
+                "children": [
+                  {
+                    "text": "special",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "λαός",
+                "morph": "Gr,N,,,,,AMS,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G29920",
+                "content": "λαὸν",
+                "children": [
+                  {
+                    "text": "people",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "ζηλωτής",
+                "morph": "Gr,N,,,,,AMS,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G22070",
+                "content": "ζηλωτὴν",
+                "children": [
+                  {
+                    "text": "who",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  },
+                  {
+                    "text": "are",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  },
+                  {
+                    "text": "eager",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  },
+                  {
+                    "text": "to",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 3,
+                    "occurrences": 3
+                  },
+                  {
+                    "text": "do",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "καλός",
+                "morph": "Gr,AA,,,,GNP,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G25700",
+                "content": "καλῶν",
+                "children": [
+                  {
+                    "text": "good",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "ἔργον",
+                "morph": "Gr,N,,,,,GNP,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G20410",
+                "content": "ἔργων",
+                "children": [
+                  {
+                    "text": "works",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "type": "text",
+                "text": ". \n"
+              }
+            ]
+          },
+          "15": {
+            "verseObjects": [
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "λαλέω",
+                "morph": "Gr,VTMPA2,,S,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G29800",
+                "content": "λάλει",
+                "children": [
+                  {
+                    "text": "Speak",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "οὗτος",
+                "morph": "Gr,RD,,,,ANP,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G37780",
+                "content": "ταῦτα",
+                "children": [
+                  {
+                    "text": "of",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  },
+                  {
+                    "text": "these",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  },
+                  {
+                    "text": "things",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "type": "text",
+                "text": ","
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "καί",
+                "morph": "Gr,CC,,,,,,,,",
+                "occurrence": 1,
+                "occurrences": 2,
+                "strong": "G25320",
+                "content": "καὶ",
+                "children": [
+                  {
+                    "tag": "zaln",
+                    "type": "milestone",
+                    "lemma": "παρακαλέω",
+                    "morph": "Gr,VIMPA2,,S,",
+                    "occurrence": 1,
+                    "occurrences": 1,
+                    "strong": "G38700",
+                    "content": "παρακάλει",
+                    "children": [
+                      {
+                        "text": "encourage",
+                        "tag": "w",
+                        "type": "word",
+                        "occurrence": 1,
+                        "occurrences": 1
+                      },
+                      {
+                        "text": "people",
+                        "tag": "w",
+                        "type": "word",
+                        "occurrence": 1,
+                        "occurrences": 1
+                      },
+                      {
+                        "text": "to",
+                        "tag": "w",
+                        "type": "word",
+                        "occurrence": 1,
+                        "occurrences": 1
+                      },
+                      {
+                        "text": "do",
+                        "tag": "w",
+                        "type": "word",
+                        "occurrence": 1,
+                        "occurrences": 1
+                      },
+                      {
+                        "text": "them",
+                        "tag": "w",
+                        "type": "word",
+                        "occurrence": 1,
+                        "occurrences": 1
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "text",
+                "text": ","
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "καί",
+                "morph": "Gr,CC,,,,,,,,",
+                "occurrence": 2,
+                "occurrences": 2,
+                "strong": "G25320",
+                "content": "καὶ",
+                "children": [
+                  {
+                    "text": "and",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "ἐλέγχω",
+                "morph": "Gr,VIMPA2,,S,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G16510",
+                "content": "ἔλεγχε",
+                "children": [
+                  {
+                    "text": "give",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  },
+                  {
+                    "text": "correction",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "μετά",
+                "morph": "Gr,P,,,,,G,,,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G33260",
+                "content": "μετὰ",
+                "children": [
+                  {
+                    "text": "with",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "πᾶς",
+                "morph": "Gr,EQ,,,,GFS,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G39560",
+                "content": "πάσης",
+                "children": [
+                  {
+                    "text": "all",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "ἐπιταγή",
+                "morph": "Gr,N,,,,,GFS,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G20030",
+                "content": "ἐπιταγῆς",
+                "children": [
+                  {
+                    "text": "authority",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "type": "text",
+                "text": "."
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "περιφρονέω",
+                "morph": "Gr,VTMPA3,,S,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G40650",
+                "content": "περιφρονείτω",
+                "children": [
+                  {
+                    "text": "Let",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "μηδείς",
+                "morph": "Gr,RI,,,,NMS,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G33670",
+                "content": "μηδείς",
+                "children": [
+                  {
+                    "text": "no",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  },
+                  {
+                    "text": "one",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "περιφρονέω",
+                "morph": "Gr,VTMPA3,,S,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G40650",
+                "content": "περιφρονείτω",
+                "children": [
+                  {
+                    "text": "disregard",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "tag": "zaln",
+                "type": "milestone",
+                "lemma": "σύ",
+                "morph": "Gr,RP,,,2G,S,",
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G47710",
+                "content": "σου",
+                "children": [
+                  {
+                    "text": "you",
+                    "tag": "w",
+                    "type": "word",
+                    "occurrence": 1,
+                    "occurrences": 1
+                  }
+                ]
+              },
+              {
+                "type": "text",
+                "text": ".\n"
+              }
+            ]
+          }
+        },
+        "manifest": {
+          "language_id": "en",
+          "language_name": "English",
+          "direction": "ltr",
+          "subject": "Bible",
+          "resource_id": "ult",
+          "resource_title": "unfoldingWord Literal Text",
+          "description": "Gateway Language"
         }
       }
     },
-    "translationHelps": {
-      "translationWords": {
-        "faithful": "# faithful, faithfulness #\n\n## Definition: ##\n\nTo be \"faithful\" to God means to consistently live according to God's teachings. It means to be loyal to him by obeying him.The state or condition of being faithful is \"faithfulness.\"\n\n* A person who is faithful can be trusted to always keep his promises and to always fulfill his responsibilities to other people.\n* A faithful person perseveres in doing a task, even when it is long and difficult.\n* Faithfulness to God is the consistent practice of doing what God wants us to do.\n\n## Translation Suggestions: ##\n\n* In many contexts, \"faithful\" can be translated as \"loyal\" or \"dedicated\" or \"dependable.\"\n* In other contexts, \"faithful\" can be translated by a word or phrase that means \"continuing to believe\" or \"persevering in believing and obeying God.\"\n* Ways that \"faithfulness\" could be translated could include \"persevering in believing\" or \"loyalty\" or \"trustworthiness\" or \"believing and obeying God.\"\n\n(See also: [faith](../kt/faith.md), [believe](../kt/believe.md))\n\n## Bible References: ##\n\n* [1 Samuel 02:9](rc://en/tn/help/1sa/02/09)\n* [1 Thessalonians 05:23-24](rc://en/tn/help/1th/05/23)\n* [3 John 01:5-8](rc://en/tn/help/3jn/01/05)\n* [Colossians 01:7-8](rc://en/tn/help/col/01/07)\n* [Genesis 24:49](rc://en/tn/help/gen/24/49)\n* [Isaiah 01:26](rc://en/tn/help/isa/01/26)\n* [Joshua 02:14](rc://en/tn/help/jos/02/14)\n* [Luke 16:10-12](rc://en/tn/help/luk/16/10)\n* [Numbers 12:6-8](rc://en/tn/help/num/12/06)\n* [Proverbs 11:12-13](rc://en/tn/help/pro/11/12)\n* [Psalm 012:1](rc://en/tn/help/psa/012/001)\n\n## Examples from the Bible stories: ##\n\n* __[08:05](rc://en/tn/help/obs/08/05)__ Even in prison, Joseph remained __faithful__  to God, and God blessed him.\n* __[14:12](rc://en/tn/help/obs/14/12)__ Even so, God was still __faithful__  to His promises to Abraham, Isaac, and Jacob.\n* __[15:13](rc://en/tn/help/obs/15/13)__ The people promised to remain __faithful__  to God and follow his laws.\n* __[17:09](rc://en/tn/help/obs/17/09)__ David ruled with justice and __faithfulness__  for many years, and God blessed him. However, toward the end of his life he sinned terribly against God.\n* __[18:04](rc://en/tn/help/obs/18/04)__ God was angry with Solomon and, as a punishment for Solomon's __unfaithfulness__, he promised to divide the nation of Israel into two kingdoms after Solomon's death.\n* __[35:12](rc://en/tn/help/obs/35/12)__ \"The older son said to his father, 'All these years I have worked __faithfully__  for you!\"\n* __[49:17](rc://en/tn/help/obs/49/17)__ But God is __faithful__  and says that if you confess your sins, he will forgive you.\n* __[50:04](rc://en/tn/help/obs/50/04)__ If you remain __faithful__  to me to the end, then God will save you.\"\n\n## Word Data:##\n\n* Strong's: H529, H530, H539, H540, H571, G4103\n\n"
-      }
-    },
-    "lexicons": {}
-  },
-  "commentsReducer": {
-    "text": "",
-    "userName": "",
-    "modifiedTimestamp": ""
-  },
-  "remindersReducer": {
-    "enabled": false,
-    "userName": "",
-    "modifiedTimestamp": ""
-  },
-  "contextIdReducer": {
-    "contextId": {
-      "reference": {
-        "bookId": "tit",
-        "chapter": 2,
-        "verse": 5
+    "targetLanguage": {
+      "2": {
+        "1": "Kono ewe, oambe ziyenderera ne ntaero zisepahara. ",
+        "2": "Bakwame bakuru baswanera kuba no buiswaro, kuki kutika, ne nkutwisiso, nentumero irukite, ne rato ne tundamo.",
+        "3": "Abakentu bakulwana nabo nji nto iswana baswanera kubona kuti nako yonshe ba kikutika, kali kushebeka. Kaba swaneli kunywa caha bujwara. Baswanera kuruta zirotu asf",
+        "4": "kuti  abakazana bazyibe kuha erato ke nkutwisiso ku bakwame babo ne bana bo. ",
+        "5": "Baswanera kuba ruta ku shuwisisa, kucena ko kuki babarera, no kubabarera marapa abo, no kukutika abakwame babo. Baswanezi kutenda ezi zintu ye ezywi lya Nyambe lya shauliwa.",
+        "6": "Kenjira iswana mu ereze banenu be cikwame babe ne nkutwisiso. ",
+        "7": "Muzonshe, muhare ko mutara omisebezi mirotu, hape entuto yenu isunde kucena ne kute. ",
+        "8": "Oambe eñusa ligorete lyazya mafosisa kuti enshe ozyo arwisa aswabe, kakuli kali kawane chimango cho kuamba.",
+        "9": "Abatanga ba swanezi kuki bika kwinshi yi banfumu babo muzintu zonshe. Baba tabise kali kuba kakana. ",
+        "10": "Bashahibi. Kono, basunde entumero yonshe ndotu, kuti yee muzintu zonshe bakutike entuto yetu ya Nyambe mupulusi wetu.",
+        "11": "Kakuli echishemo cha Nyambe cha bonahali ku bantu bonshe. ",
+        "12": "Chitu ruta okukana bumango ne ntakazo zefasi. Chitu ruta okuhara ke kutwisiso, ko kucena, mane ni ke chirumeli moinu nako, ",
+        "13": "netu lindire okutambura ensepo yetu ifuyaulitwe, kusunda okucena kwa Nyambe wetu omunene ne mupulusi Jesu Kireste.",
+        "14": "Jesu nakiha yemwini kwetu ko kutu rukurura kuzintu zonshe zaazya murao, noku cenesa, kebaka lyakwe, abantu bobutokwa aba kitakaleza kutenda misebezi mirotu.",
+        "15": "Ambe no kususueza kezi zintu. Usikulure ke manta onshe. Kwashabi ozyo akana kuku shuwa.",
+        "-1": "Kubatuka 2"
       },
-      "tool": "translationWords",
-      "groupId": "god",
-      "quote": "Θεοῦ",
-      "strong": ["G23160"],
-      "occurrence": 1
+      "manifest": {
+        "language_id": "fwe",
+        "language_name": "Fwe",
+        "direction": "ltr",
+        "subject": "Bible",
+        "resource_id": "targetLanguage",
+        "resource_title": "",
+        "description": "Target Language"
+      }
     }
   },
-  "projectDetailsReducer": {
-    "projectSaveLocation": "/Users/jay/translationCore/projects/fwe_tit_text_reg",
-    "manifest": {
-      "generator": {
-        "name": "ts-desktop",
-        "build": "110"
-      },
-      "target_language": {
-        "id": "fwe",
-        "name": "Fwe",
-        "direction": "ltr"
-      },
-      "ts_project": {
-        "id": "tit",
-        "name": "Titus"
-      },
-      "toolsSelectedGLs": {
-        "translationWords": "en",
-        "wordAlignment": "en"
-      },
-      "type": {
-        "id": "text",
-        "name": "Text"
-      },
-      "source_translations": [
-        {
-          "language_id": "en",
-          "resource_id": "ult",
-          "checking_level": "3",
-          "date_modified": 20170221,
-          "version": "9"
-        }
-      ],
-      "translators": [
-        "Jane Wachila",
-        "Ruth Lutuhezi",
-        "kapokola alfred simbotwe",
-        "Philip McMahon",
-        "gravy"
-      ],
-      "checkers": [],
-      "time_created": "3/25/2017 4:21 PM",
-      "check_modules": [],
-      "package_version": 7,
-      "format": "usfm",
-      "project": {
-        "id": "tit",
-        "name": "Titus"
-      },
-      "resource": {
-        "id": "reg",
-        "name": "Regular"
-      },
-      "parent_draft": {},
-      "finished_chunks": [
-        "01-01",
-        "01-04",
-        "01-06",
-        "01-08",
-        "01-10",
-        "01-12",
-        "01-14",
-        "01-15",
-        "01-title",
-        "02-01",
-        "02-03",
-        "02-06",
-        "02-09",
-        "02-11",
-        "02-14",
-        "02-15",
-        "02-title",
-        "03-01",
-        "03-03",
-        "03-04",
-        "03-06",
-        "03-08",
-        "03-09",
-        "03-12",
-        "03-14",
-        "03-15",
-        "03-title"
-      ],
-      "tcInitialized": true,
-      "license": "CC0 1.0 Public Domain"
+  "commentText": "",
+  "bookmarkEnabled": false,
+  "contextId": {
+    "reference": {
+      "bookId": "tit",
+      "chapter": 2,
+      "verse": 5
     },
-    "currentProjectToolsProgress": {
-      "wordAlignment": 0,
-      "translationWords": 0
-    },
-    "projectType": null
+    "tool": "translationWords",
+    "groupId": "god",
+    "quote": "Θεοῦ",
+    "strong": ["G23160"],
+    "occurrence": 1
   },
-  "selectionsReducer": {
-    "selections": [],
-    "userName": "",
-    "modifiedTimestamp": ""
+  "targetLanguageDetails": {
+    "id": "fwe",
+    "name": "Fwe",
+    "direction": "ltr"
   },
-  "verseEditReducer": {
-    "tags": [],
-    "userName": [],
-    "modifiedTimestamp": ""
+  "bookDetails": {
+    "id": "tit",
+    "name": "Titus"
   },
-  "groupsIndexReducer": {
-    "groupsIndex": [
-      {
-        "id": "abomination",
-        "name": "abomination, abominations, abominable"
-      },
-      {
-        "id": "adoption",
-        "name": "adoption, adopt, adopted"
-      },
-      {
-        "id": "adultery",
-        "name": "adultery, adulterous, adulterer, adulteress, adulterers, adulteresses"
-      },
-      {
-        "id": "almighty",
-        "name": "Almighty"
-      },
-      {
-        "id": "altar",
-        "name": "altar, altars"
-      },
-      {
-        "id": "amen",
-        "name": "amen, truly"
-      },
-      {
-        "id": "angel",
-        "name": "angel, angels, archangel"
-      },
-      {
-        "id": "anoint",
-        "name": "anoint, anointed, anointing"
-      },
-      {
-        "id": "antichrist",
-        "name": "antichrist, antichrists"
-      },
-      {
-        "id": "apostle",
-        "name": "apostle, apostles, apostleship"
-      },
-      {
-        "id": "appoint",
-        "name": "appoint, appoints, appointed"
-      },
-      {
-        "id": "ark",
-        "name": "ark"
-      },
-      {
-        "id": "arkofthecovenant",
-        "name": "ark of the covenant, ark of Yahweh"
-      },
-      {
-        "id": "atonement",
-        "name": "atonement, atone, atones, atoned"
-      },
-      {
-        "id": "atonementlid",
-        "name": "atonement lid"
-      },
-      {
-        "id": "authority",
-        "name": "authority, authorities"
-      },
-      {
-        "id": "baptize",
-        "name": "baptize, baptized, baptism"
-      },
-      {
-        "id": "believe",
-        "name": "believe, believes, believed, believer, belief, unbeliever, unbelievers, unbelief"
-      },
-      {
-        "id": "beloved",
-        "name": "beloved"
-      },
-      {
-        "id": "bond",
-        "name": "bind, bond, bound"
-      },
-      {
-        "id": "birthright",
-        "name": "birthright"
-      },
-      {
-        "id": "blameless",
-        "name": "blameless"
-      },
-      {
-        "id": "blasphemy",
-        "name": "blasphemy, blaspheme, blasphemed, blasphemous, blasphemies"
-      },
-      {
-        "id": "bless",
-        "name": "bless, blessed, blessing"
-      },
-      {
-        "id": "blood",
-        "name": "blood"
-      },
-      {
-        "id": "boast",
-        "name": "boast, boasts, boastful"
-      },
-      {
-        "id": "body",
-        "name": "body, bodies"
-      },
-      {
-        "id": "bornagain",
-        "name": "born again, born of God, new birth"
-      },
-      {
-        "id": "brother",
-        "name": "brother, brothers"
-      },
-      {
-        "id": "call",
-        "name": "call, calls, calling, called"
-      },
-      {
-        "id": "centurion",
-        "name": "centurion, centurions"
-      },
-      {
-        "id": "children",
-        "name": "children, child"
-      },
-      {
-        "id": "elect",
-        "name": "chosen one, chosen ones, choose, chosen people, Chosen One, elect"
-      },
-      {
-        "id": "christ",
-        "name": "Christ, Messiah"
-      },
-      {
-        "id": "christian",
-        "name": "Christian"
-      },
-      {
-        "id": "church",
-        "name": "church, churches, Church"
-      },
-      {
-        "id": "circumcise",
-        "name": "circumcise, circumcised, circumcision, uncircumcised, uncircumcision"
-      },
-      {
-        "id": "clean",
-        "name": "clean, cleans, cleaned, cleanse, cleansed, cleansing, wash, washing, washed, washes, unclean"
-      },
-      {
-        "id": "command",
-        "name": "command, commands, commanded, commandment, commandments"
-      },
-      {
-        "id": "compassion",
-        "name": "compassion, compassionate"
-      },
-      {
-        "id": "condemn",
-        "name": "condemn, condemns, condemned, condemnation"
-      },
-      {
-        "id": "confess",
-        "name": "confess, confessed, confesses, confession"
-      },
-      {
-        "id": "conscience",
-        "name": "conscience, consciences"
-      },
-      {
-        "id": "consecrate",
-        "name": "consecrate, consecrated, consecration"
-      },
-      {
-        "id": "cornerstone",
-        "name": "cornerstone, cornerstones"
-      },
-      {
-        "id": "covenant",
-        "name": "covenant, covenants, new covenant"
-      },
-      {
-        "id": "covenantfaith",
-        "name": "covenant faithfulness, covenant loyalty, loving kindness, unfailing love"
-      },
-      {
-        "id": "cross",
-        "name": "cross"
-      },
-      {
-        "id": "crucify",
-        "name": "crucify, crucified"
-      },
-      {
-        "id": "curse",
-        "name": "curse, cursed, curses, cursing"
-      },
-      {
-        "id": "daughterofzion",
-        "name": "daughter of Zion"
-      },
-      {
-        "id": "dayofthelord",
-        "name": "day of the Lord, day of Yahweh"
-      },
-      {
-        "id": "deacon",
-        "name": "deacon, deacons"
-      },
-      {
-        "id": "demon",
-        "name": "demon, evil spirit, unclean spirit"
-      },
-      {
-        "id": "demonpossessed",
-        "name": "demon-possessed"
-      },
-      {
-        "id": "disciple",
-        "name": "disciple, disciples"
-      },
-      {
-        "id": "discipline",
-        "name": "discipline, disciplines, disciplined, self-discipline"
-      },
-      {
-        "id": "divine",
-        "name": "divine"
-      },
-      {
-        "id": "dominion",
-        "name": "dominion"
-      },
-      {
-        "id": "ephod",
-        "name": "ephod"
-      },
-      {
-        "id": "eternity",
-        "name": "eternity, everlasting, eternal, forever"
-      },
-      {
-        "id": "eunuch",
-        "name": "eunuch, eunuchs"
-      },
-      {
-        "id": "evangelism",
-        "name": "evangelist, evangelists"
-      },
-      {
-        "id": "evil",
-        "name": "evil, wicked, wickedness"
-      },
-      {
-        "id": "exalt",
-        "name": "exalt, exalted, exalts, exaltation"
-      },
-      {
-        "id": "exhort",
-        "name": "exhort, exhortation"
-      },
-      {
-        "id": "faith",
-        "name": "faith"
-      },
-      {
-        "id": "faithful",
-        "name": "faithful, faithfulness, unfaithful, unfaithfulness"
-      },
-      {
-        "id": "faithless",
-        "name": "faithless, faithlessness"
-      },
-      {
-        "id": "favor",
-        "name": "favor, favors, favorable, favoritism"
-      },
-      {
-        "id": "fear",
-        "name": "fear, fears, afraid"
-      },
-      {
-        "id": "fellowship",
-        "name": "fellowship"
-      },
-      {
-        "id": "filled",
-        "name": "filled with the Holy Spirit"
-      },
-      {
-        "id": "flesh",
-        "name": "flesh"
-      },
-      {
-        "id": "foolish",
-        "name": "fool, fools, foolish, folly"
-      },
-      {
-        "id": "forgive",
-        "name": "forgive, forgives, forgiven, forgiveness, pardon, pardoned"
-      },
-      {
-        "id": "forsaken",
-        "name": "forsake, forsakes, forsaken, forsook"
-      },
-      {
-        "id": "fulfill",
-        "name": "fulfill, fulfilled"
-      },
-      {
-        "id": "gentile",
-        "name": "Gentile, Gentiles"
-      },
-      {
-        "id": "gift",
-        "name": "gift, gifts"
-      },
-      {
-        "id": "glory",
-        "name": "glory, glorious, glorify, glorifies"
-      },
-      {
-        "id": "god",
-        "name": "God"
-      },
-      {
-        "id": "falsegod",
-        "name": "god, false god, gods, goddess, idol, idols, idolater, idolaters, idolatrous, idolatry"
-      },
-      {
-        "id": "godthefather",
-        "name": "God the Father, heavenly Father, Father"
-      },
-      {
-        "id": "godly",
-        "name": "godly, godliness, ungodly, godless, ungodliness, godlessness"
-      },
-      {
-        "id": "good",
-        "name": "good, goodness"
-      },
-      {
-        "id": "goodnews",
-        "name": "good news, gospel"
-      },
-      {
-        "id": "grace",
-        "name": "grace, gracious"
-      },
-      {
-        "id": "guilt",
-        "name": "guilt, guilty"
-      },
-      {
-        "id": "hades",
-        "name": "Hades, Sheol"
-      },
-      {
-        "id": "heart",
-        "name": "heart, hearts"
-      },
-      {
-        "id": "heaven",
-        "name": "heaven, sky, skies, heavens, heavenly"
-      },
-      {
-        "id": "hebrew",
-        "name": "Hebrew, Hebrews"
-      },
-      {
-        "id": "hell",
-        "name": "hell, lake of fire"
-      },
-      {
-        "id": "highpriest",
-        "name": "high priest"
-      },
-      {
-        "id": "holy",
-        "name": "holy, holiness, unholy, sacred"
-      },
-      {
-        "id": "holyone",
-        "name": "Holy One"
-      },
-      {
-        "id": "holyplace",
-        "name": "holy place"
-      },
-      {
-        "id": "holyspirit",
-        "name": "Holy Spirit, Spirit of God, Spirit of the Lord, Spirit"
-      },
-      {
-        "id": "honor",
-        "name": "honor, honors"
-      },
-      {
-        "id": "hope",
-        "name": "hope, hoped, hopes"
-      },
-      {
-        "id": "houseofgod",
-        "name": "house of God, Yahweh's house"
-      },
-      {
-        "id": "humble",
-        "name": "humble, humbles, humbled, humility"
-      },
-      {
-        "id": "hypocrite",
-        "name": "hypocrite, hypocrites, hypocrisy"
-      },
-      {
-        "id": "imageofgod",
-        "name": "image of God, image"
-      },
-      {
-        "id": "inchrist",
-        "name": "in Christ, in Jesus, in the Lord, in him"
-      },
-      {
-        "id": "inherit",
-        "name": "inherit, inheritance, heritage, heir"
-      },
-      {
-        "id": "iniquity",
-        "name": "iniquity, iniquities"
-      },
-      {
-        "id": "innocent",
-        "name": "innocent"
-      },
-      {
-        "id": "intercede",
-        "name": "intercede, intercededs, intercession"
-      },
-      {
-        "id": "israel",
-        "name": "Israel, Israelites"
-      },
-      {
-        "id": "jealous",
-        "name": "jealous, jealousy"
-      },
-      {
-        "id": "jesus",
-        "name": "Jesus, Jesus Christ, Christ Jesus"
-      },
-      {
-        "id": "jew",
-        "name": "Jew, Jewish, Jews"
-      },
-      {
-        "id": "judge",
-        "name": "judge, judges, judgment, judgments"
-      },
-      {
-        "id": "judgmentday",
-        "name": "judgment day"
-      },
-      {
-        "id": "justice",
-        "name": "just, justice, unjust, unjustly, injustice, justly, justify, justification"
-      },
-      {
-        "id": "kingofthejews",
-        "name": "King of the Jews, king of the Jews"
-      },
-      {
-        "id": "kingdomofgod",
-        "name": "kingdom of God, kingdom of heaven"
-      },
-      {
-        "id": "lamb",
-        "name": "lamb, Lamb of God"
-      },
-      {
-        "id": "lament",
-        "name": "lament, laments, lamentation"
-      },
-      {
-        "id": "lastday",
-        "name": "last day, last days, latter days"
-      },
-      {
-        "id": "lawofmoses",
-        "name": "law, law of Moses, God's law, law of Yahweh"
-      },
-      {
-        "id": "life",
-        "name": "life, live, lived, lives, living, alive"
-      },
-      {
-        "id": "lord",
-        "name": "lord, lords, Lord, master, masters, sir, sirs"
-      },
-      {
-        "id": "lordyahweh",
-        "name": "Lord Yahweh, Yahweh God"
-      },
-      {
-        "id": "lordssupper",
-        "name": "Lord's Supper"
-      },
-      {
-        "id": "love",
-        "name": "love, loves, loving, loved"
-      },
-      {
-        "id": "majesty",
-        "name": "majesty"
-      },
-      {
-        "id": "manna",
-        "name": "manna"
-      },
-      {
-        "id": "mercy",
-        "name": "mercy, merciful"
-      },
-      {
-        "id": "miracle",
-        "name": "miracle, miracles, wonder, wonders, sign, signs"
-      },
-      {
-        "id": "mosthigh",
-        "name": "Most High"
-      },
-      {
-        "id": "myrrh",
-        "name": "myrrh"
-      },
-      {
-        "id": "name",
-        "name": "name, names, named"
-      },
-      {
-        "id": "nazirite",
-        "name": "Nazirite, Nazirites, Nazirite vow"
-      },
-      {
-        "id": "parable",
-        "name": "parable, parables"
-      },
-      {
-        "id": "passover",
-        "name": "Passover"
-      },
-      {
-        "id": "pastor",
-        "name": "pastor, pastors"
-      },
-      {
-        "id": "pentecost",
-        "name": "Pentecost, Festival of Weeks"
-      },
-      {
-        "id": "peopleofgod",
-        "name": "people of God, my people"
-      },
-      {
-        "id": "perish",
-        "name": "perish, perished, perishing, perishable"
-      },
-      {
-        "id": "pharisee",
-        "name": "Pharisee, Pharisees"
-      },
-      {
-        "id": "power",
-        "name": "power, powers"
-      },
-      {
-        "id": "pray",
-        "name": "pray, prayer, prayers, prayed"
-      },
-      {
-        "id": "predestine",
-        "name": "predestine, predestined"
-      },
-      {
-        "id": "priest",
-        "name": "priest, priests, priesthood"
-      },
-      {
-        "id": "promise",
-        "name": "promise, promises, promised"
-      },
-      {
-        "id": "promisedland",
-        "name": "Promised Land"
-      },
-      {
-        "id": "prophet",
-        "name": "prophet, prophets, prophecy, prophesy, seer, prophetess"
-      },
-      {
-        "id": "propitiation",
-        "name": "propitiation"
-      },
-      {
-        "id": "psalm",
-        "name": "psalm, psalms"
-      },
-      {
-        "id": "purify",
-        "name": "pure, purify, purification"
-      },
-      {
-        "id": "rabbi",
-        "name": "Rabbi"
-      },
-      {
-        "id": "ransom",
-        "name": "ransom, ransomed"
-      },
-      {
-        "id": "reconcile",
-        "name": "reconcile, reconciles, reconciled, reconciliation"
-      },
-      {
-        "id": "redeem",
-        "name": "redeem, redeems, redemption, redeemer"
-      },
-      {
-        "id": "remnant",
-        "name": "remnant"
-      },
-      {
-        "id": "repent",
-        "name": "repent, repents, repented, repentance"
-      },
-      {
-        "id": "restore",
-        "name": "restore, restores, restored, restoration"
-      },
-      {
-        "id": "resurrection",
-        "name": "resurrection"
-      },
-      {
-        "id": "reveal",
-        "name": "reveal, reveals, revealed, revelation"
-      },
-      {
-        "id": "righthand",
-        "name": "right hand"
-      },
-      {
-        "id": "righteous",
-        "name": "righteous, righteousness, unrighteous, unrighteousness, upright, uprightness"
-      },
-      {
-        "id": "sabbath",
-        "name": "Sabbath"
-      },
-      {
-        "id": "sadducee",
-        "name": "Sadducee, Sadducees"
-      },
-      {
-        "id": "saint",
-        "name": "saint, saints"
-      },
-      {
-        "id": "sanctify",
-        "name": "sanctify, sanctifies, sanctification"
-      },
-      {
-        "id": "sanctuary",
-        "name": "sanctuary"
-      },
-      {
-        "id": "satan",
-        "name": "Satan, devil, evil one"
-      },
-      {
-        "id": "save",
-        "name": "save, saves, saved, safe, salvation"
-      },
-      {
-        "id": "savior",
-        "name": "Savior, savior"
-      },
-      {
-        "id": "scribe",
-        "name": "scribe, scribes"
-      },
-      {
-        "id": "setapart",
-        "name": "set apart"
-      },
-      {
-        "id": "sign",
-        "name": "sign, signs, proof, reminder"
-      },
-      {
-        "id": "sin",
-        "name": "sin, sins, sinned, sinful, sinner, sinning"
-      },
-      {
-        "id": "son",
-        "name": "son, sons"
-      },
-      {
-        "id": "sonofgod",
-        "name": "Son of God, Son"
-      },
-      {
-        "id": "sonofman",
-        "name": "Son of Man, son of man"
-      },
-      {
-        "id": "sonsofgod",
-        "name": "sons of God"
-      },
-      {
-        "id": "soul",
-        "name": "soul, souls"
-      },
-      {
-        "id": "spirit",
-        "name": "spirit, spirits, spiritual"
-      },
-      {
-        "id": "stone",
-        "name": "stone, stones, stoning"
-      },
-      {
-        "id": "synagogue",
-        "name": "synagogue"
-      },
-      {
-        "id": "tabernacle",
-        "name": "tabernacle"
-      },
-      {
-        "id": "temple",
-        "name": "temple"
-      },
-      {
-        "id": "tempt",
-        "name": "tempt, temptation"
-      },
-      {
-        "id": "test",
-        "name": "test, tests, tested"
-      },
-      {
-        "id": "testimony",
-        "name": "testimony, testify, witness, witnesses, eyewitness, eyewitnesses"
-      },
-      {
-        "id": "tetrarch",
-        "name": "tetrarch"
-      },
-      {
-        "id": "thetwelve",
-        "name": "the twelve, the eleven"
-      },
-      {
-        "id": "minister",
-        "name": "to minister, ministry"
-      },
-      {
-        "id": "transgression",
-        "name": "transgress, transgresses, transgression"
-      },
-      {
-        "id": "trespass",
-        "name": "trespass, trespasses, trespassed"
-      },
-      {
-        "id": "true",
-        "name": "true, truth, truths"
-      },
-      {
-        "id": "trust",
-        "name": "trust, trusts, trusted, trustworthy, trustworthiness"
-      },
-      {
-        "id": "unleavenedbread",
-        "name": "unleavened bread"
-      },
-      {
-        "id": "vow",
-        "name": "vow, vows, vowed"
-      },
-      {
-        "id": "willofgod",
-        "name": "will of God"
-      },
-      {
-        "id": "wise",
-        "name": "wise, wisdom"
-      },
-      {
-        "id": "woe",
-        "name": "woe"
-      },
-      {
-        "id": "wordofgod",
-        "name": "word of God, words of God, word of Yahweh, word of the Lord, word of truth, scripture, scriptures"
-      },
-      {
-        "id": "works",
-        "name": "works, deeds, work, acts"
-      },
-      {
-        "id": "world",
-        "name": "world, worldly"
-      },
-      {
-        "id": "worship",
-        "name": "worship"
-      },
-      {
-        "id": "worthy",
-        "name": "worthy, worth, unworthy, worthless"
-      },
-      {
-        "id": "wrath",
-        "name": "wrath, fury"
-      },
-      {
-        "id": "yahweh",
-        "name": "Yahweh"
-      },
-      {
-        "id": "yahwehofhosts",
-        "name": "Yahweh of hosts, God of hosts, host of heaven, host of the heavens, Lord of hosts"
-      },
-      {
-        "id": "zealous",
-        "name": "zeal, zealous"
-      },
-      {
-        "id": "zion",
-        "name": "Zion, Mount Zion"
-      }
-    ],
-    "loadedFromFileSystem": true
-  },
-  "groupsDataReducer": {
-    "groupsData": {
-      "apostle": [
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 1,
-              "verse": 1
-            },
-            "tool": "translationWords",
-            "groupId": "apostle",
-            "quote": "ἀπόστολος",
-            "strong": [
-              "G06520"
-            ],
-            "occurrence": 1
-          }
-        }
-      ],
-      "authority": [
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 2,
-              "verse": 15
-            },
-            "tool": "translationWords",
-            "groupId": "authority",
-            "quote": "ἐπιταγῆς",
-            "strong": [
-              "G20030"
-            ],
-            "occurrence": 1
-          }
-        },
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 3,
-              "verse": 1
-            },
-            "tool": "translationWords",
-            "groupId": "authority",
-            "quote": "ἐξουσίαις",
-            "strong": [
-              "G18490"
-            ],
-            "occurrence": 1
-          }
-        }
-      ],
-      "believe": [
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 1,
-              "verse": 15
-            },
-            "tool": "translationWords",
-            "groupId": "believe",
-            "quote": "ἀπίστοις",
-            "strong": [
-              "G05710"
-            ],
-            "occurrence": 1
-          }
-        },
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 3,
-              "verse": 8
-            },
-            "tool": "translationWords",
-            "groupId": "believe",
-            "quote": "πεπιστευκότες",
-            "strong": [
-              "G41000"
-            ],
-            "occurrence": 1
-          }
-        }
-      ],
-      "blameless": [
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 1,
-              "verse": 6
-            },
-            "tool": "translationWords",
-            "groupId": "blameless",
-            "quote": "ἀνέγκλητος",
-            "strong": [
-              "G04100"
-            ],
-            "occurrence": 1
-          }
-        },
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 1,
-              "verse": 7
-            },
-            "tool": "translationWords",
-            "groupId": "blameless",
-            "quote": "ἀνέγκλητον",
-            "strong": [
-              "G04100"
-            ],
-            "occurrence": 1
-          }
-        }
-      ],
-      "blasphemy": [
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 2,
-              "verse": 5
-            },
-            "tool": "translationWords",
-            "groupId": "blasphemy",
-            "quote": "βλασφημῆται",
-            "strong": [
-              "G09870"
-            ],
-            "occurrence": 1
-          }
-        },
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 3,
-              "verse": 2
-            },
-            "tool": "translationWords",
-            "groupId": "blasphemy",
-            "quote": "βλασφημεῖν",
-            "strong": [
-              "G09870"
-            ],
-            "occurrence": 1
-          }
-        }
-      ],
-      "bless": [
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 2,
-              "verse": 13
-            },
-            "tool": "translationWords",
-            "groupId": "bless",
-            "quote": "μακαρίαν",
-            "strong": [
-              "G31070"
-            ],
-            "occurrence": 1
-          }
-        }
-      ],
-      "bornagain": [
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 3,
-              "verse": 5
-            },
-            "tool": "translationWords",
-            "groupId": "bornagain",
-            "quote": "παλινγενεσίας",
-            "strong": [
-              "G38240"
-            ],
-            "occurrence": 1
-          }
-        }
-      ],
-      "children": [
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 1,
-              "verse": 6
-            },
-            "tool": "translationWords",
-            "groupId": "children",
-            "quote": "τέκνα",
-            "strong": [
-              "G50430"
-            ],
-            "occurrence": 1
-          }
-        }
-      ],
-      "christ": [
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 1,
-              "verse": 1
-            },
-            "tool": "translationWords",
-            "groupId": "christ",
-            "quote": "Χριστοῦ",
-            "strong": [
-              "G55470"
-            ],
-            "occurrence": 1
-          }
-        },
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 1,
-              "verse": 4
-            },
-            "tool": "translationWords",
-            "groupId": "christ",
-            "quote": "Χριστοῦ",
-            "strong": [
-              "G55470"
-            ],
-            "occurrence": 1
-          }
-        },
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 2,
-              "verse": 13
-            },
-            "tool": "translationWords",
-            "groupId": "christ",
-            "quote": "Χριστοῦ",
-            "strong": [
-              "G55470"
-            ],
-            "occurrence": 1
-          }
-        },
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 3,
-              "verse": 6
-            },
-            "tool": "translationWords",
-            "groupId": "christ",
-            "quote": "Χριστοῦ",
-            "strong": [
-              "G55470"
-            ],
-            "occurrence": 1
-          }
-        }
-      ],
-      "circumcise": [
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 1,
-              "verse": 10
-            },
-            "tool": "translationWords",
-            "groupId": "circumcise",
-            "quote": "περιτομῆς",
-            "strong": [
-              "G40610"
-            ],
-            "occurrence": 1
-          }
-        }
-      ],
-      "command": [
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 1,
-              "verse": 3
-            },
-            "tool": "translationWords",
-            "groupId": "command",
-            "quote": "ἐπιταγὴν",
-            "strong": [
-              "G20030"
-            ],
-            "occurrence": 1
-          }
-        },
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 1,
-              "verse": 14
-            },
-            "tool": "translationWords",
-            "groupId": "command",
-            "quote": "ἐντολαῖς",
-            "strong": [
-              "G17850"
-            ],
-            "occurrence": 1
-          }
-        }
-      ],
-      "condemn": [
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 3,
-              "verse": 11
-            },
-            "tool": "translationWords",
-            "groupId": "condemn",
-            "quote": "αὐτοκατάκριτος",
-            "strong": [
-              "G08430"
-            ],
-            "occurrence": 1
-          }
-        }
-      ],
-      "conscience": [
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 1,
-              "verse": 15
-            },
-            "tool": "translationWords",
-            "groupId": "conscience",
-            "quote": "συνείδησις",
-            "strong": [
-              "G48930"
-            ],
-            "occurrence": 1
-          }
-        }
-      ],
-      "discipline": [
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 1,
-              "verse": 8
-            },
-            "tool": "translationWords",
-            "groupId": "discipline",
-            "quote": "ἐγκρατῆ",
-            "strong": [
-              "G14680"
-            ],
-            "occurrence": 1
-          }
-        },
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 2,
-              "verse": 12
-            },
-            "tool": "translationWords",
-            "groupId": "discipline",
-            "quote": "παιδεύουσα",
-            "strong": [
-              "G38110"
-            ],
-            "occurrence": 1
-          }
-        }
-      ],
-      "elect": [
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 1,
-              "verse": 1
-            },
-            "tool": "translationWords",
-            "groupId": "elect",
-            "quote": "ἐκλεκτῶν",
-            "strong": [
-              "G15880"
-            ],
-            "occurrence": 1
-          }
-        }
-      ],
-      "eternity": [
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 1,
-              "verse": 2
-            },
-            "tool": "translationWords",
-            "groupId": "eternity",
-            "quote": "αἰωνίου",
-            "strong": [
-              "G01660"
-            ],
-            "occurrence": 1
-          }
-        },
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 1,
-              "verse": 2
-            },
-            "tool": "translationWords",
-            "groupId": "eternity",
-            "quote": "αἰωνίων",
-            "strong": [
-              "G01660"
-            ],
-            "occurrence": 1
-          }
-        },
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 3,
-              "verse": 7
-            },
-            "tool": "translationWords",
-            "groupId": "eternity",
-            "quote": "αἰωνίου",
-            "strong": [
-              "G01660"
-            ],
-            "occurrence": 1
-          }
-        }
-      ],
-      "evil": [
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 1,
-              "verse": 12
-            },
-            "tool": "translationWords",
-            "groupId": "evil",
-            "quote": "κακὰ",
-            "strong": [
-              "G25560"
-            ],
-            "occurrence": 1
-          }
-        },
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 2,
-              "verse": 8
-            },
-            "tool": "translationWords",
-            "groupId": "evil",
-            "quote": "φαῦλον",
-            "strong": [
-              "G53370"
-            ],
-            "occurrence": 1
-          }
-        },
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 3,
-              "verse": 3
-            },
-            "tool": "translationWords",
-            "groupId": "evil",
-            "quote": "κακίᾳ",
-            "strong": [
-              "G25490"
-            ],
-            "occurrence": 1
-          }
-        }
-      ],
-      "exhort": [
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 2,
-              "verse": 6
-            },
-            "tool": "translationWords",
-            "groupId": "exhort",
-            "quote": "παρακάλει",
-            "strong": [
-              "G38700"
-            ],
-            "occurrence": 1
-          }
-        },
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 2,
-              "verse": 15
-            },
-            "tool": "translationWords",
-            "groupId": "exhort",
-            "quote": "παρακάλει",
-            "strong": [
-              "G38700"
-            ],
-            "occurrence": 1
-          }
-        }
-      ],
-      "faith": [
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 1,
-              "verse": 1
-            },
-            "tool": "translationWords",
-            "groupId": "faith",
-            "quote": "πίστιν",
-            "strong": [
-              "G41020"
-            ],
-            "occurrence": 1
-          }
-        },
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 1,
-              "verse": 4
-            },
-            "tool": "translationWords",
-            "groupId": "faith",
-            "quote": "πίστιν",
-            "strong": [
-              "G41020"
-            ],
-            "occurrence": 1
-          }
-        },
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 1,
-              "verse": 13
-            },
-            "tool": "translationWords",
-            "groupId": "faith",
-            "quote": "πίστει",
-            "strong": [
-              "G41020"
-            ],
-            "occurrence": 1
-          }
-        },
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 2,
-              "verse": 2
-            },
-            "tool": "translationWords",
-            "groupId": "faith",
-            "quote": "πίστει",
-            "strong": [
-              "G41020"
-            ],
-            "occurrence": 1
-          }
-        },
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 2,
-              "verse": 10
-            },
-            "tool": "translationWords",
-            "groupId": "faith",
-            "quote": "πίστιν",
-            "strong": [
-              "G41020"
-            ],
-            "occurrence": 1
-          }
-        },
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 3,
-              "verse": 15
-            },
-            "tool": "translationWords",
-            "groupId": "faith",
-            "quote": "πίστει",
-            "strong": [
-              "G41020"
-            ],
-            "occurrence": 1
-          }
-        }
-      ],
-      "faithful": [
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 1,
-              "verse": 6
-            },
-            "tool": "translationWords",
-            "groupId": "faithful",
-            "quote": "πιστά",
-            "strong": [
-              "G41030"
-            ],
-            "occurrence": 1
-          }
-        },
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 1,
-              "verse": 9
-            },
-            "tool": "translationWords",
-            "groupId": "faithful",
-            "quote": "πιστοῦ",
-            "strong": [
-              "G41030"
-            ],
-            "occurrence": 1
-          }
-        },
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 3,
-              "verse": 8
-            },
-            "tool": "translationWords",
-            "groupId": "faithful",
-            "quote": "πιστὸς",
-            "strong": [
-              "G41030"
-            ],
-            "occurrence": 1
-          }
-        }
-      ],
-      "foolish": [
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 3,
-              "verse": 3
-            },
-            "tool": "translationWords",
-            "groupId": "foolish",
-            "quote": "ἀνόητοι",
-            "strong": [
-              "G04530"
-            ],
-            "occurrence": 1
-          }
-        },
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 3,
-              "verse": 9
-            },
-            "tool": "translationWords",
-            "groupId": "foolish",
-            "quote": "μωρὰς",
-            "strong": [
-              "G34740"
-            ],
-            "occurrence": 1
-          }
-        }
-      ],
-      "glory": [
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 2,
-              "verse": 13
-            },
-            "tool": "translationWords",
-            "groupId": "glory",
-            "quote": "δόξης",
-            "strong": [
-              "G13910"
-            ],
-            "occurrence": 1
-          }
-        }
-      ],
-      "god": [
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 1,
-              "verse": 1
-            },
-            "tool": "translationWords",
-            "groupId": "god",
-            "quote": "Θεοῦ",
-            "strong": [
-              "G23160"
-            ],
-            "occurrence": 1
-          }
-        },
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 1,
-              "verse": 1
-            },
-            "tool": "translationWords",
-            "groupId": "god",
-            "quote": "Θεοῦ",
-            "strong": [
-              "G23160"
-            ],
-            "occurrence": 2
-          }
-        },
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 1,
-              "verse": 2
-            },
-            "tool": "translationWords",
-            "groupId": "god",
-            "quote": "Θεὸς",
-            "strong": [
-              "G23160"
-            ],
-            "occurrence": 1
-          }
-        },
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 1,
-              "verse": 3
-            },
-            "tool": "translationWords",
-            "groupId": "god",
-            "quote": "Θεοῦ",
-            "strong": [
-              "G23160"
-            ],
-            "occurrence": 1
-          }
-        },
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 1,
-              "verse": 4
-            },
-            "tool": "translationWords",
-            "groupId": "god",
-            "quote": "Θεοῦ",
-            "strong": [
-              "G23160"
-            ],
-            "occurrence": 1
-          }
-        },
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 1,
-              "verse": 7
-            },
-            "tool": "translationWords",
-            "groupId": "god",
-            "quote": "Θεοῦ",
-            "strong": [
-              "G23160"
-            ],
-            "occurrence": 1
-          }
-        },
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 1,
-              "verse": 16
-            },
-            "tool": "translationWords",
-            "groupId": "god",
-            "quote": "Θεὸν",
-            "strong": [
-              "G23160"
-            ],
-            "occurrence": 1
-          }
-        },
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 2,
-              "verse": 5
-            },
-            "tool": "translationWords",
-            "groupId": "god",
-            "quote": "Θεοῦ",
-            "strong": [
-              "G23160"
-            ],
-            "occurrence": 1
-          }
-        },
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 2,
-              "verse": 10
-            },
-            "tool": "translationWords",
-            "groupId": "god",
-            "quote": "Θεοῦ",
-            "strong": [
-              "G23160"
-            ],
-            "occurrence": 1
-          }
-        },
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 2,
-              "verse": 11
-            },
-            "tool": "translationWords",
-            "groupId": "god",
-            "quote": "Θεοῦ",
-            "strong": [
-              "G23160"
-            ],
-            "occurrence": 1
-          }
-        },
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 2,
-              "verse": 13
-            },
-            "tool": "translationWords",
-            "groupId": "god",
-            "quote": "Θεοῦ",
-            "strong": [
-              "G23160"
-            ],
-            "occurrence": 1
-          }
-        },
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 3,
-              "verse": 4
-            },
-            "tool": "translationWords",
-            "groupId": "god",
-            "quote": "Θεοῦ",
-            "strong": [
-              "G23160"
-            ],
-            "occurrence": 1
-          }
-        },
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 3,
-              "verse": 8
-            },
-            "tool": "translationWords",
-            "groupId": "god",
-            "quote": "Θεῷ",
-            "strong": [
-              "G23160"
-            ],
-            "occurrence": 1
-          }
-        }
-      ],
-      "godly": [
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 1,
-              "verse": 1
-            },
-            "tool": "translationWords",
-            "groupId": "godly",
-            "quote": "εὐσέβειαν",
-            "strong": [
-              "G21500"
-            ],
-            "occurrence": 1
-          }
-        },
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 2,
-              "verse": 12
-            },
-            "tool": "translationWords",
-            "groupId": "godly",
-            "quote": "ἀσέβειαν",
-            "strong": [
-              "G07630"
-            ],
-            "occurrence": 1
-          }
-        },
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 2,
-              "verse": 12
-            },
-            "tool": "translationWords",
-            "groupId": "godly",
-            "quote": "εὐσεβῶς",
-            "strong": [
-              "G21530"
-            ],
-            "occurrence": 1
-          }
-        }
-      ],
-      "godthefather": [
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 1,
-              "verse": 4
-            },
-            "tool": "translationWords",
-            "groupId": "godthefather",
-            "quote": "Θεοῦ Πατρὸς",
-            "strong": [
-              "G23160",
-              "G39620"
-            ],
-            "occurrence": 1
-          }
-        }
-      ],
-      "good": [
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 1,
-              "verse": 8
-            },
-            "tool": "translationWords",
-            "groupId": "good",
-            "quote": "φιλάγαθον",
-            "strong": [
-              "G53580"
-            ],
-            "occurrence": 1
-          }
-        },
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 1,
-              "verse": 16
-            },
-            "tool": "translationWords",
-            "groupId": "good",
-            "quote": "ἀγαθὸν",
-            "strong": [
-              "G00180"
-            ],
-            "occurrence": 1
-          }
-        },
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 2,
-              "verse": 5
-            },
-            "tool": "translationWords",
-            "groupId": "good",
-            "quote": "ἀγαθάς",
-            "strong": [
-              "G00180"
-            ],
-            "occurrence": 1
-          }
-        },
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 2,
-              "verse": 7
-            },
-            "tool": "translationWords",
-            "groupId": "good",
-            "quote": "καλῶν",
-            "strong": [
-              "G25700"
-            ],
-            "occurrence": 1
-          }
-        },
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 2,
-              "verse": 10
-            },
-            "tool": "translationWords",
-            "groupId": "good",
-            "quote": "ἀγαθήν",
-            "strong": [
-              "G00180"
-            ],
-            "occurrence": 1
-          }
-        },
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 2,
-              "verse": 14
-            },
-            "tool": "translationWords",
-            "groupId": "good",
-            "quote": "καλῶν",
-            "strong": [
-              "G25700"
-            ],
-            "occurrence": 1
-          }
-        },
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 3,
-              "verse": 1
-            },
-            "tool": "translationWords",
-            "groupId": "good",
-            "quote": "ἀγαθὸν",
-            "strong": [
-              "G00180"
-            ],
-            "occurrence": 1
-          }
-        },
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 3,
-              "verse": 8
-            },
-            "tool": "translationWords",
-            "groupId": "good",
-            "quote": "καλῶν",
-            "strong": [
-              "G25700"
-            ],
-            "occurrence": 1
-          }
-        },
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 3,
-              "verse": 8
-            },
-            "tool": "translationWords",
-            "groupId": "good",
-            "quote": "καλὰ",
-            "strong": [
-              "G25700"
-            ],
-            "occurrence": 1
-          }
-        },
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 3,
-              "verse": 14
-            },
-            "tool": "translationWords",
-            "groupId": "good",
-            "quote": "καλῶν",
-            "strong": [
-              "G25700"
-            ],
-            "occurrence": 1
-          }
-        }
-      ],
-      "grace": [
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 1,
-              "verse": 4
-            },
-            "tool": "translationWords",
-            "groupId": "grace",
-            "quote": "χάρις",
-            "strong": [
-              "G54850"
-            ],
-            "occurrence": 1
-          }
-        },
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 2,
-              "verse": 11
-            },
-            "tool": "translationWords",
-            "groupId": "grace",
-            "quote": "χάρις",
-            "strong": [
-              "G54850"
-            ],
-            "occurrence": 1
-          }
-        },
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 3,
-              "verse": 7
-            },
-            "tool": "translationWords",
-            "groupId": "grace",
-            "quote": "χάριτι",
-            "strong": [
-              "G54850"
-            ],
-            "occurrence": 1
-          }
-        },
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 3,
-              "verse": 15
-            },
-            "tool": "translationWords",
-            "groupId": "grace",
-            "quote": "χάρις",
-            "strong": [
-              "G54850"
-            ],
-            "occurrence": 1
-          }
-        }
-      ],
-      "holy": [
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 1,
-              "verse": 8
-            },
-            "tool": "translationWords",
-            "groupId": "holy",
-            "quote": "ὅσιον",
-            "strong": [
-              "G37410"
-            ],
-            "occurrence": 1
-          }
-        },
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 3,
-              "verse": 5
-            },
-            "tool": "translationWords",
-            "groupId": "holy",
-            "quote": "Ἁγίου",
-            "strong": [
-              "G00400"
-            ],
-            "occurrence": 1
-          }
-        }
-      ],
-      "holyspirit": [
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 3,
-              "verse": 5
-            },
-            "tool": "translationWords",
-            "groupId": "holyspirit",
-            "quote": "Πνεύματος Ἁγίου",
-            "strong": [
-              "G41510",
-              "G00400"
-            ],
-            "occurrence": 1
-          }
-        }
-      ],
-      "hope": [
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 1,
-              "verse": 2
-            },
-            "tool": "translationWords",
-            "groupId": "hope",
-            "quote": "ἐλπίδι",
-            "strong": [
-              "G16800"
-            ],
-            "occurrence": 1
-          }
-        },
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 2,
-              "verse": 13
-            },
-            "tool": "translationWords",
-            "groupId": "hope",
-            "quote": "ἐλπίδα",
-            "strong": [
-              "G16800"
-            ],
-            "occurrence": 1
-          }
-        },
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 3,
-              "verse": 7
-            },
-            "tool": "translationWords",
-            "groupId": "hope",
-            "quote": "ἐλπίδα",
-            "strong": [
-              "G16800"
-            ],
-            "occurrence": 1
-          }
-        }
-      ],
-      "humble": [
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 3,
-              "verse": 2
-            },
-            "tool": "translationWords",
-            "groupId": "humble",
-            "quote": "πραΰτητα",
-            "strong": [
-              "G42400"
-            ],
-            "occurrence": 1
-          }
-        }
-      ],
-      "jesus": [
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 1,
-              "verse": 1
-            },
-            "tool": "translationWords",
-            "groupId": "jesus",
-            "quote": "Ἰησοῦ Χριστοῦ",
-            "strong": [
-              "G24240",
-              "G55470"
-            ],
-            "occurrence": 1
-          }
-        },
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 1,
-              "verse": 4
-            },
-            "tool": "translationWords",
-            "groupId": "jesus",
-            "quote": "Χριστοῦ Ἰησοῦ",
-            "strong": [
-              "G55470",
-              "G24240"
-            ],
-            "occurrence": 1
-          }
-        },
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 2,
-              "verse": 13
-            },
-            "tool": "translationWords",
-            "groupId": "jesus",
-            "quote": "Ἰησοῦ Χριστοῦ",
-            "strong": [
-              "G24240",
-              "G55470"
-            ],
-            "occurrence": 1
-          }
-        },
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 3,
-              "verse": 6
-            },
-            "tool": "translationWords",
-            "groupId": "jesus",
-            "quote": "Ἰησοῦ Χριστοῦ",
-            "strong": [
-              "G24240",
-              "G55470"
-            ],
-            "occurrence": 1
-          }
-        }
-      ],
-      "jew": [
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 1,
-              "verse": 14
-            },
-            "tool": "translationWords",
-            "groupId": "jew",
-            "quote": "Ἰουδαϊκοῖς",
-            "strong": [
-              "G24510"
-            ],
-            "occurrence": 1
-          }
-        }
-      ],
-      "justice": [
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 3,
-              "verse": 7
-            },
-            "tool": "translationWords",
-            "groupId": "justice",
-            "quote": "δικαιωθέντες",
-            "strong": [
-              "G13440"
-            ],
-            "occurrence": 1
-          }
-        }
-      ],
-      "lawofmoses": [
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 3,
-              "verse": 9
-            },
-            "tool": "translationWords",
-            "groupId": "lawofmoses",
-            "quote": "νομικὰς",
-            "strong": [
-              "G35440"
-            ],
-            "occurrence": 1
-          }
-        }
-      ],
-      "life": [
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 1,
-              "verse": 2
-            },
-            "tool": "translationWords",
-            "groupId": "life",
-            "quote": "ζωῆς",
-            "strong": [
-              "G22220"
-            ],
-            "occurrence": 1
-          }
-        },
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 2,
-              "verse": 12
-            },
-            "tool": "translationWords",
-            "groupId": "life",
-            "quote": "ζήσωμεν",
-            "strong": [
-              "G21980"
-            ],
-            "occurrence": 1
-          }
-        },
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 3,
-              "verse": 7
-            },
-            "tool": "translationWords",
-            "groupId": "life",
-            "quote": "ζωῆς",
-            "strong": [
-              "G22220"
-            ],
-            "occurrence": 1
-          }
-        }
-      ],
-      "live": [
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 3,
-              "verse": 3
-            },
-            "tool": "translationWords",
-            "groupId": "live",
-            "quote": "διάγοντες",
-            "strong": [
-              "G12360"
-            ],
-            "occurrence": 1
-          }
-        }
-      ],
-      "lord": [
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 2,
-              "verse": 9
-            },
-            "tool": "translationWords",
-            "groupId": "lord",
-            "quote": "δεσπόταις",
-            "strong": [
-              "G12030"
-            ],
-            "occurrence": 1
-          }
-        }
-      ],
-      "love": [
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 2,
-              "verse": 2
-            },
-            "tool": "translationWords",
-            "groupId": "love",
-            "quote": "ἀγάπῃ",
-            "strong": [
-              "G00260"
-            ],
-            "occurrence": 1
-          }
-        },
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 2,
-              "verse": 4
-            },
-            "tool": "translationWords",
-            "groupId": "love",
-            "quote": "φιλάνδρους",
-            "strong": [
-              "G53620"
-            ],
-            "occurrence": 1
-          }
-        },
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 2,
-              "verse": 4
-            },
-            "tool": "translationWords",
-            "groupId": "love",
-            "quote": "φιλοτέκνους",
-            "strong": [
-              "G53880"
-            ],
-            "occurrence": 1
-          }
-        },
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 3,
-              "verse": 4
-            },
-            "tool": "translationWords",
-            "groupId": "love",
-            "quote": "φιλανθρωπία",
-            "strong": [
-              "G53630"
-            ],
-            "occurrence": 1
-          }
-        },
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 3,
-              "verse": 15
-            },
-            "tool": "translationWords",
-            "groupId": "love",
-            "quote": "φιλοῦντας",
-            "strong": [
-              "G53680"
-            ],
-            "occurrence": 1
-          }
-        }
-      ],
-      "mercy": [
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 3,
-              "verse": 5
-            },
-            "tool": "translationWords",
-            "groupId": "mercy",
-            "quote": "ἔλεος",
-            "strong": [
-              "G16560"
-            ],
-            "occurrence": 1
-          }
-        }
-      ],
-      "power": [
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 1,
-              "verse": 9
-            },
-            "tool": "translationWords",
-            "groupId": "power",
-            "quote": "δυνατὸς",
-            "strong": [
-              "G14150"
-            ],
-            "occurrence": 1
-          }
-        }
-      ],
-      "promise": [
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 1,
-              "verse": 2
-            },
-            "tool": "translationWords",
-            "groupId": "promise",
-            "quote": "ἐπηγγείλατο",
-            "strong": [
-              "G18610"
-            ],
-            "occurrence": 1
-          }
-        }
-      ],
-      "prophet": [
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 1,
-              "verse": 12
-            },
-            "tool": "translationWords",
-            "groupId": "prophet",
-            "quote": "προφήτης",
-            "strong": [
-              "G43960"
-            ],
-            "occurrence": 1
-          }
-        }
-      ],
-      "purify": [
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 1,
-              "verse": 15
-            },
-            "tool": "translationWords",
-            "groupId": "purify",
-            "quote": "καθαρὰ",
-            "strong": [
-              "G25130"
-            ],
-            "occurrence": 1
-          }
-        },
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 1,
-              "verse": 15
-            },
-            "tool": "translationWords",
-            "groupId": "purify",
-            "quote": "καθαροῖς",
-            "strong": [
-              "G25130"
-            ],
-            "occurrence": 1
-          }
-        },
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 1,
-              "verse": 15
-            },
-            "tool": "translationWords",
-            "groupId": "purify",
-            "quote": "καθαρόν",
-            "strong": [
-              "G25130"
-            ],
-            "occurrence": 1
-          }
-        },
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 2,
-              "verse": 5
-            },
-            "tool": "translationWords",
-            "groupId": "purify",
-            "quote": "ἁγνάς",
-            "strong": [
-              "G00530"
-            ],
-            "occurrence": 1
-          }
-        }
-      ],
-      "redeem": [
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 2,
-              "verse": 14
-            },
-            "tool": "translationWords",
-            "groupId": "redeem",
-            "quote": "λυτρώσηται",
-            "strong": [
-              "G30840"
-            ],
-            "occurrence": 1
-          }
-        }
-      ],
-      "reveal": [
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 1,
-              "verse": 3
-            },
-            "tool": "translationWords",
-            "groupId": "reveal",
-            "quote": "ἐφανέρωσεν",
-            "strong": [
-              "G53190"
-            ],
-            "occurrence": 1
-          }
-        }
-      ],
-      "righteous": [
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 1,
-              "verse": 8
-            },
-            "tool": "translationWords",
-            "groupId": "righteous",
-            "quote": "δίκαιον",
-            "strong": [
-              "G13420"
-            ],
-            "occurrence": 1
-          }
-        },
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 2,
-              "verse": 12
-            },
-            "tool": "translationWords",
-            "groupId": "righteous",
-            "quote": "δικαίως",
-            "strong": [
-              "G13460"
-            ],
-            "occurrence": 1
-          }
-        },
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 3,
-              "verse": 5
-            },
-            "tool": "translationWords",
-            "groupId": "righteous",
-            "quote": "δικαιοσύνῃ",
-            "strong": [
-              "G13430"
-            ],
-            "occurrence": 1
-          }
-        }
-      ],
-      "save": [
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 2,
-              "verse": 11
-            },
-            "tool": "translationWords",
-            "groupId": "save",
-            "quote": "σωτήριος",
-            "strong": [
-              "G49920"
-            ],
-            "occurrence": 1
-          }
-        },
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 3,
-              "verse": 5
-            },
-            "tool": "translationWords",
-            "groupId": "save",
-            "quote": "ἔσωσεν",
-            "strong": [
-              "G49820"
-            ],
-            "occurrence": 1
-          }
-        }
-      ],
-      "savior": [
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 1,
-              "verse": 3
-            },
-            "tool": "translationWords",
-            "groupId": "savior",
-            "quote": "Σωτῆρος",
-            "strong": [
-              "G49900"
-            ],
-            "occurrence": 1
-          }
-        },
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 1,
-              "verse": 4
-            },
-            "tool": "translationWords",
-            "groupId": "savior",
-            "quote": "Σωτῆρος",
-            "strong": [
-              "G49900"
-            ],
-            "occurrence": 1
-          }
-        },
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 2,
-              "verse": 10
-            },
-            "tool": "translationWords",
-            "groupId": "savior",
-            "quote": "Σωτῆρος",
-            "strong": [
-              "G49900"
-            ],
-            "occurrence": 1
-          }
-        },
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 2,
-              "verse": 13
-            },
-            "tool": "translationWords",
-            "groupId": "savior",
-            "quote": "Σωτῆρος",
-            "strong": [
-              "G49900"
-            ],
-            "occurrence": 1
-          }
-        },
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 3,
-              "verse": 4
-            },
-            "tool": "translationWords",
-            "groupId": "savior",
-            "quote": "Σωτῆρος",
-            "strong": [
-              "G49900"
-            ],
-            "occurrence": 1
-          }
-        },
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 3,
-              "verse": 6
-            },
-            "tool": "translationWords",
-            "groupId": "savior",
-            "quote": "Σωτῆρος",
-            "strong": [
-              "G49900"
-            ],
-            "occurrence": 1
-          }
-        }
-      ],
-      "sin": [
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 3,
-              "verse": 11
-            },
-            "tool": "translationWords",
-            "groupId": "sin",
-            "quote": "ἁμαρτάνει",
-            "strong": [
-              "G02640"
-            ],
-            "occurrence": 1
-          }
-        }
-      ],
-      "son": [
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 1,
-              "verse": 4
-            },
-            "tool": "translationWords",
-            "groupId": "son",
-            "quote": "τέκνῳ",
-            "strong": [
-              "G50430"
-            ],
-            "occurrence": 1
-          }
-        }
-      ],
-      "testimony": [
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 1,
-              "verse": 13
-            },
-            "tool": "translationWords",
-            "groupId": "testimony",
-            "quote": "μαρτυρία",
-            "strong": [
-              "G31410"
-            ],
-            "occurrence": 1
-          }
-        }
-      ],
-      "true": [
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 1,
-              "verse": 1
-            },
-            "tool": "translationWords",
-            "groupId": "true",
-            "quote": "ἀληθείας",
-            "strong": [
-              "G02250"
-            ],
-            "occurrence": 1
-          }
-        },
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 1,
-              "verse": 4
-            },
-            "tool": "translationWords",
-            "groupId": "true",
-            "quote": "γνησίῳ",
-            "strong": [
-              "G11030"
-            ],
-            "occurrence": 1
-          }
-        },
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 1,
-              "verse": 13
-            },
-            "tool": "translationWords",
-            "groupId": "true",
-            "quote": "ἀληθής",
-            "strong": [
-              "G02270"
-            ],
-            "occurrence": 1
-          }
-        },
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 1,
-              "verse": 14
-            },
-            "tool": "translationWords",
-            "groupId": "true",
-            "quote": "ἀλήθειαν",
-            "strong": [
-              "G02250"
-            ],
-            "occurrence": 1
-          }
-        }
-      ],
-      "trust": [
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 1,
-              "verse": 3
-            },
-            "tool": "translationWords",
-            "groupId": "trust",
-            "quote": "ἐπιστεύθην",
-            "strong": [
-              "G41000"
-            ],
-            "occurrence": 1
-          }
-        }
-      ],
-      "wordofgod": [
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 1,
-              "verse": 3
-            },
-            "tool": "translationWords",
-            "groupId": "wordofgod",
-            "quote": "λόγον",
-            "strong": [
-              "G30560"
-            ],
-            "occurrence": 1
-          }
-        },
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 2,
-              "verse": 5
-            },
-            "tool": "translationWords",
-            "groupId": "wordofgod",
-            "quote": "λόγος τοῦ Θεοῦ",
-            "strong": [
-              "G30560",
-              "G35880",
-              "G23160"
-            ],
-            "occurrence": 1
-          }
-        }
-      ],
-      "works": [
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 1,
-              "verse": 16
-            },
-            "tool": "translationWords",
-            "groupId": "works",
-            "quote": "ἔργοις",
-            "strong": [
-              "G20410"
-            ],
-            "occurrence": 1
-          }
-        },
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 1,
-              "verse": 16
-            },
-            "tool": "translationWords",
-            "groupId": "works",
-            "quote": "ἔργον",
-            "strong": [
-              "G20410"
-            ],
-            "occurrence": 1
-          }
-        },
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 2,
-              "verse": 7
-            },
-            "tool": "translationWords",
-            "groupId": "works",
-            "quote": "ἔργων",
-            "strong": [
-              "G20410"
-            ],
-            "occurrence": 1
-          }
-        },
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 2,
-              "verse": 14
-            },
-            "tool": "translationWords",
-            "groupId": "works",
-            "quote": "ἔργων",
-            "strong": [
-              "G20410"
-            ],
-            "occurrence": 1
-          }
-        },
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 3,
-              "verse": 1
-            },
-            "tool": "translationWords",
-            "groupId": "works",
-            "quote": "ἔργον",
-            "strong": [
-              "G20410"
-            ],
-            "occurrence": 1
-          }
-        },
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 3,
-              "verse": 5
-            },
-            "tool": "translationWords",
-            "groupId": "works",
-            "quote": "ἔργων",
-            "strong": [
-              "G20410"
-            ],
-            "occurrence": 1
-          }
-        },
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 3,
-              "verse": 8
-            },
-            "tool": "translationWords",
-            "groupId": "works",
-            "quote": "ἔργων",
-            "strong": [
-              "G20410"
-            ],
-            "occurrence": 1
-          }
-        },
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 3,
-              "verse": 14
-            },
-            "tool": "translationWords",
-            "groupId": "works",
-            "quote": "ἔργων",
-            "strong": [
-              "G20410"
-            ],
-            "occurrence": 1
-          }
-        }
-      ],
-      "world": [
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 2,
-              "verse": 12
-            },
-            "tool": "translationWords",
-            "groupId": "world",
-            "quote": "κοσμικὰς",
-            "strong": [
-              "G28860"
-            ],
-            "occurrence": 1
-          }
-        }
-      ],
-      "zealous": [
-        {
-          "priority": 1,
-          "comments": false,
-          "reminders": false,
-          "selections": false,
-          "verseEdits": false,
-          "contextId": {
-            "reference": {
-              "bookId": "tit",
-              "chapter": 2,
-              "verse": 14
-            },
-            "tool": "translationWords",
-            "groupId": "zealous",
-            "quote": "ζηλωτὴν",
-            "strong": [
-              "G22070"
-            ],
-            "occurrence": 1
-          }
-        }
-      ]
-    },
-    "loadedFromFileSystem": true
-  },
-  "wordAlignmentReducer": {
-    "alignmentData": {}
-  },
+  "selections": [],
+  "newSelections": [],
+  "tags": [],
   "actions": {},
-  "currentToolViews": {},
-  "showHelps": true,
   "mode": "select",
   "comment": "",
   "commentChanged": false,
   "verseText": "Kono ewe, oambe ziyenderera ne ntaero zisepahara. ",
   "unfilteredVerseText": "Kono ewe, oambe ziyenderera ne ntaero zisepahara.\n\\s5\n",
   "verseChanged": false,
-  "selections": [],
-  "tags": [],
   "dialogModalVisibility": false,
   "goToNextOrPrevious": null
 }

--- a/src/VerseCheck/__tests__/fixtures/project/loadedProjectShortened.json
+++ b/src/VerseCheck/__tests__/fixtures/project/loadedProjectShortened.json
@@ -4836,10 +4836,10 @@
   "actions": {},
   "mode": "select",
   "comment": "",
-  "commentChanged": false,
+  "isCommentChanged": false,
   "verseText": "Kono ewe, oambe ziyenderera ne ntaero zisepahara. ",
   "unfilteredVerseText": "Kono ewe, oambe ziyenderera ne ntaero zisepahara.\n\\s5\n",
-  "verseChanged": false,
+  "isVerseChanged": false,
   "dialogModalVisibility": false,
   "goToNextOrPrevious": null
 }

--- a/tc-ui-toolkit-test/src/App.js
+++ b/tc-ui-toolkit-test/src/App.js
@@ -147,7 +147,7 @@ class App extends Component {
               commentChanged={false}
               localNothingToSelect={false}
               verseChanged={false}
-              bibles={bibles}
+              targetBible={bibles.targetLanguage.targetBible}
               bookDetails={this.state.projectDetailsReducer.manifest.project}
               targetLanguageDetails={this.state.projectDetailsReducer.manifest.target_language}
             />

--- a/tc-ui-toolkit-test/src/App.js
+++ b/tc-ui-toolkit-test/src/App.js
@@ -144,9 +144,9 @@ class App extends Component {
               unfilteredVerseText={''}
               bookmarkEnabled={false}
               isVerseInvalidated={false}
-              commentChanged={false}
+              isCommentChanged={false}
               localNothingToSelect={false}
-              verseChanged={false}
+              isVerseChanged={false}
               targetBible={bibles.targetLanguage.targetBible}
               bookDetails={this.state.projectDetailsReducer.manifest.project}
               targetLanguageDetails={this.state.projectDetailsReducer.manifest.target_language}

--- a/tc-ui-toolkit-test/src/App.js
+++ b/tc-ui-toolkit-test/src/App.js
@@ -24,6 +24,11 @@ import groupsDataReducer from './assets/groupsDataReducer'
 import groupsIndexReducer from './assets/groupsIndexReducer'
 import groupMenuReducer from './assets/groupMenuReducer'
 import toolsReducer from './assets/toolsReducer'
+import selectionsReducer from './assets/selectionsReducer'
+// import resourcesReducer from './assets/resourcesReducer'
+// import commentsReducer from './assets/commentsReducer'
+// import remindersReducer from './assets/remindersReducer'
+// import loginReducer from './assets/loginReducer'
 // files
 import { article } from './assets/thelps';
 
@@ -38,7 +43,9 @@ class App extends Component {
       },
       tags: [],
       mode: 'default',
-      nothingToSelect: false
+      nothingToSelect: false,
+      selectionsReducer,
+      projectDetailsReducer,
     };
   }
 
@@ -108,27 +115,42 @@ class App extends Component {
               toggleHelps={this.toggleHelps.bind(this)}
               showHelps={this.state.showHelps} />
             <VerseCheck
+              {...verseCheckActions}
               mode={this.state.mode}
               tags={this.state.tags}
-              actions={{
-                ...verseCheckActions,
-                handleTagsCheckbox: (tag) => this.setState({ tags: [...this.state.tags, tag] }),
-                changeMode: (mode) => this.setState({ mode }),
-                cancelComment: () => this.setState({ mode: 'default' }),
-                cancelEditVerse: () => this.setState({ mode: 'default' }),
-              }}
+              contextId={contextId}
+              handleTagsCheckbox={(tag) => this.setState({ tags: [...this.state.tags, tag] })}
+              changeMode={(mode) => this.setState({ mode })}
+              cancelComment={() => this.setState({ mode: 'default' })}
+              cancelEditVerse={() => this.setState({ mode: 'default' })}
               toggleNothingToSelect={nothingToSelect => this.setState({ nothingToSelect })}
-              // selections={verseCheckSelections}
+              selections={this.state.selectionsReducer.selections}
               saveSelection={() => this.setState({ mode: 'default' })}
               nothingToSelect={this.state.nothingToSelect}
-              selectionsReducer={{nothingToSelect: this.state.nothingToSelect, selections: []}}
               cancelSelection={() => this.setState({ mode: 'default' })}
+              clearSelection={() => {
+                this.setState({ selectionsReducer: { selections: [] }})
+              }}
               translate={k => k}
+              newSelections={[]}
               verseText={'dummy text'}
               findIfVerseEdited={() => (true)}
               findIfVerseInvalidated={() => (true)}
               alignedGLText={'Dummy'}
-              maximumSelections={5} />
+              maximumSelections={5}
+              verseEdited={false}
+              commentText={''}
+              dialogModalVisibility={false}
+              unfilteredVerseText={''}
+              bookmarkEnabled={false}
+              isVerseInvalidated={false}
+              commentChanged={false}
+              localNothingToSelect={false}
+              verseChanged={false}
+              bibles={bibles}
+              bookDetails={this.state.projectDetailsReducer.manifest.project}
+              targetLanguageDetails={this.state.projectDetailsReducer.manifest.target_language}
+            />
           </div>
           <TranslationHelps
             modalArticle={article}

--- a/tc-ui-toolkit-test/src/assets/commentsReducer.js
+++ b/tc-ui-toolkit-test/src/assets/commentsReducer.js
@@ -1,0 +1,5 @@
+const commentsReducer = {
+  text: ''
+}
+
+export default commentsReducer

--- a/tc-ui-toolkit-test/src/assets/loginReducer.js
+++ b/tc-ui-toolkit-test/src/assets/loginReducer.js
@@ -1,0 +1,5 @@
+const loginReducer = {
+
+}
+
+export default loginReducer

--- a/tc-ui-toolkit-test/src/assets/remindersReducer.js
+++ b/tc-ui-toolkit-test/src/assets/remindersReducer.js
@@ -1,0 +1,5 @@
+const remindersReducer = {
+  enabled: false
+}
+
+export default remindersReducer

--- a/tc-ui-toolkit-test/src/assets/resourcesReducer.js
+++ b/tc-ui-toolkit-test/src/assets/resourcesReducer.js
@@ -1,0 +1,13 @@
+const resourcesReducer = {
+  bibles: {
+    targetLanguage: {
+      targetBible: {
+        1: {
+          1: ''
+        }
+      }
+    }
+  }
+}
+
+export default resourcesReducer;

--- a/tc-ui-toolkit-test/src/assets/selectionsReducer.js
+++ b/tc-ui-toolkit-test/src/assets/selectionsReducer.js
@@ -1,0 +1,6 @@
+const selectionsReducer = {
+  selections: [],
+  nothingToSelect: false,
+}
+
+export default selectionsReducer;

--- a/tc-ui-toolkit-test/src/assets/verseCheckProps.js
+++ b/tc-ui-toolkit-test/src/assets/verseCheckProps.js
@@ -21,6 +21,9 @@ export const verseCheckActions = {
   toggleReminder: () => {},
   openAlertDialog: () => {},
   selectModalTab: () => {},
+  handleSkip: () => {},
+  handleCheckVerse: () => {},
+  handleCheckComment: () => {},
 };
 
 export const verseCheckSelections = [

--- a/tc-ui-toolkit-test/src/assets/verseCheckProps.js
+++ b/tc-ui-toolkit-test/src/assets/verseCheckProps.js
@@ -22,8 +22,8 @@ export const verseCheckActions = {
   openAlertDialog: () => {},
   selectModalTab: () => {},
   handleSkip: () => {},
-  hasVerseChanged: () => {},
-  hasCommentChanged: () => {},
+  checkIfVerseChanged: () => {},
+  checkIfCommentChanged: () => {},
 };
 
 export const verseCheckSelections = [

--- a/tc-ui-toolkit-test/src/assets/verseCheckProps.js
+++ b/tc-ui-toolkit-test/src/assets/verseCheckProps.js
@@ -22,7 +22,7 @@ export const verseCheckActions = {
   openAlertDialog: () => {},
   selectModalTab: () => {},
   handleSkip: () => {},
-  handleCheckVerse: () => {},
+  hasVerseChanged: () => {},
   hasCommentChanged: () => {},
 };
 

--- a/tc-ui-toolkit-test/src/assets/verseCheckProps.js
+++ b/tc-ui-toolkit-test/src/assets/verseCheckProps.js
@@ -23,7 +23,7 @@ export const verseCheckActions = {
   selectModalTab: () => {},
   handleSkip: () => {},
   handleCheckVerse: () => {},
-  handleCheckComment: () => {},
+  hasCommentChanged: () => {},
 };
 
 export const verseCheckSelections = [


### PR DESCRIPTION
- In translationCore repo checkout to `feature-mannycolon-6443-6446` and run `npm i`

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/translationcoreapps/tc-ui-toolkit/234)
<!-- Reviewable:end -->
