### PR TITLE
Feature/Add ability to see raw usfm

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,0 +1,39 @@
+# This workflow will do a clean install of node dependencies, cache/restore them, build the source code and run tests across different versions of node
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+
+name: Node.js CI
+
+on:
+  push:
+    branches: [ develop, master ]
+  pull_request:
+    branches: [ develop, master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [16.4.2]
+        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
+
+      - name: Node version
+        run: |
+          node --version
+          npm --version
+
+      - name: npm install
+        run: npm ci
+
+      - name: npm test
+        run: npm test

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "tc-ui-toolkit",
-  "version": "6.0.1-alpha",
+  "version": "6.0.1-alpha.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "6.0.1-alpha",
+      "version": "6.0.1-alpha.4",
       "license": "MIT",
       "dependencies": {
         "@material-ui/core": "^4.10.2",
@@ -20,7 +20,8 @@
         "react-container-dimensions": "^1.3.3",
         "react-draggable": "^3.3.2",
         "react-remarkable": "^1.1.3",
-        "react-tooltip": "^3.11.6"
+        "react-tooltip": "^3.11.6",
+        "tc-ui-toolkit": "github:unfoldingWord/tc-ui-toolkit#feature-mcleanb-raw-usfm"
       },
       "devDependencies": {
         "@babel/cli": "^7.8.4",
@@ -9266,6 +9267,7 @@
       "version": "16.8.6",
       "resolved": "https://registry.npmjs.org/react/-/react-16.8.6.tgz",
       "integrity": "sha512-pC0uMkhLaHm11ZSJULfOBqV4tIZkx87ZLvbbQYunNixAAvjnC+snJCg0XQXn9VIsttVsbZP/H/ewzgsd5fxKXw==",
+      "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -9340,6 +9342,7 @@
       "version": "16.8.6",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.8.6.tgz",
       "integrity": "sha512-1nL7PIq9LTL3fthPqwkvr2zY7phIPjYrT0jp4HjyEQrEROnw4dG41VVwi/wfoCneoleqrNX7iAD+pXebJZwrwA==",
+      "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -10015,6 +10018,7 @@
       "version": "0.13.6",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.13.6.tgz",
       "integrity": "sha512-IWnObHt413ucAYKsD9J1QShUKkbKLQQHdxRyw73sw4FN26iWr3DY/H34xGPe4nmL1DwXyWmSWmMrA9TfQbE/XQ==",
+      "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -10785,6 +10789,36 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/tc-ui-toolkit": {
+      "version": "6.0.1-alpha.3",
+      "resolved": "git+ssh://git@github.com/unfoldingWord/tc-ui-toolkit.git#2304fc5aa4684a3c5c84e77af2035683ee218c34",
+      "license": "MIT",
+      "dependencies": {
+        "@material-ui/core": "^4.10.2",
+        "@material-ui/icons": "^3.0.2",
+        "deep-equal": "^1.1.1",
+        "jest-environment-jsdom": "^24.9.0",
+        "lodash": "^4.17.15",
+        "marked": "^0.6.3",
+        "memoize-one": "^5.1.1",
+        "prop-types": "^15.7.2",
+        "react-bootstrap": "^0.32.1",
+        "react-container-dimensions": "^1.3.3",
+        "react-draggable": "^3.3.2",
+        "react-remarkable": "^1.1.3",
+        "react-tooltip": "^3.11.6"
+      },
+      "engines": {
+        "node": ">=6.11.0"
+      },
+      "peerDependencies": {
+        "react": "^16.3.0",
+        "react-dom": "^16.3.0",
+        "string-punctuation-tokenizer": "^2.0.0",
+        "usfm-js": "^2.1.0",
+        "word-aligner": "^1.0.0"
       }
     },
     "node_modules/terser": {
@@ -13369,8 +13403,7 @@
     "@material-ui/types": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/@material-ui/types/-/types-5.1.0.tgz",
-      "integrity": "sha512-7cqRjrY50b8QzRSYyhSpx4WRw2YuO0KKIGQEVk5J8uoz2BanawykgZGoWEqKm7pVIbzFDN0SpPcVV4IhOFkl8A==",
-      "requires": {}
+      "integrity": "sha512-7cqRjrY50b8QzRSYyhSpx4WRw2YuO0KKIGQEVk5J8uoz2BanawykgZGoWEqKm7pVIbzFDN0SpPcVV4IhOFkl8A=="
     },
     "@material-ui/utils": {
       "version": "4.10.2",
@@ -13767,8 +13800,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.2.0.tgz",
       "integrity": "sha512-HiUX/+K2YpkpJ+SzBffkM/AQ2YE03S0U1kjTLVpoJdhZMOWy8qvXVN9JdLqv2QsaQ6MPYQIuNmwD8zOiYUofLQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "acorn-walk": {
       "version": "6.2.0",
@@ -13808,15 +13840,13 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz",
       "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "ajv-keywords": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.0.tgz",
       "integrity": "sha512-eyoaac3btgU8eJlvh01En8OCKzRqlLe2G5jDsCr3RiE2uLGMEEB1aaGwVVpwR8M95956tGH6R+9edC++OvzaVw==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "ansi-escapes": {
       "version": "4.3.1",
@@ -14053,8 +14083,7 @@
       "version": "7.0.0-bridge.0",
       "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-7.0.0-bridge.0.tgz",
       "integrity": "sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "babel-eslint": {
       "version": "10.1.0",
@@ -15963,8 +15992,7 @@
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-2.5.1.tgz",
       "integrity": "sha512-Y2c4b55R+6ZzwtTppKwSmK/Kar8AdLiC2f9NADCuxbcTgPPg41Gyqa6b9GppgXSvCtkRw43ZE86CT5sejKC6/g==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "eslint-scope": {
       "version": "5.1.0",
@@ -17664,8 +17692,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.1.tgz",
       "integrity": "sha512-pgFw2tm54fzgYvc/OHrnysABEObZCUNFnhjoRjaVOCN8NYc032/gVjPaHD4Aq6ApkSieWtfKAFQtmDKAmhupnQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "jest-regex-util": {
       "version": "24.9.0",
@@ -19516,6 +19543,7 @@
       "version": "16.8.6",
       "resolved": "https://registry.npmjs.org/react/-/react-16.8.6.tgz",
       "integrity": "sha512-pC0uMkhLaHm11ZSJULfOBqV4tIZkx87ZLvbbQYunNixAAvjnC+snJCg0XQXn9VIsttVsbZP/H/ewzgsd5fxKXw==",
+      "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -19577,6 +19605,7 @@
       "version": "16.8.6",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.8.6.tgz",
       "integrity": "sha512-1nL7PIq9LTL3fthPqwkvr2zY7phIPjYrT0jp4HjyEQrEROnw4dG41VVwi/wfoCneoleqrNX7iAD+pXebJZwrwA==",
+      "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -20115,6 +20144,7 @@
       "version": "0.13.6",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.13.6.tgz",
       "integrity": "sha512-IWnObHt413ucAYKsD9J1QShUKkbKLQQHdxRyw73sw4FN26iWr3DY/H34xGPe4nmL1DwXyWmSWmMrA9TfQbE/XQ==",
+      "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -20737,6 +20767,25 @@
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.3.tgz",
       "integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==",
       "dev": true
+    },
+    "tc-ui-toolkit": {
+      "version": "git+ssh://git@github.com/unfoldingWord/tc-ui-toolkit.git#2304fc5aa4684a3c5c84e77af2035683ee218c34",
+      "from": "tc-ui-toolkit@unfoldingWord/tc-ui-toolkit#feature-mcleanb-raw-usfm",
+      "requires": {
+        "@material-ui/core": "^4.10.2",
+        "@material-ui/icons": "^3.0.2",
+        "deep-equal": "^1.1.1",
+        "jest-environment-jsdom": "^24.9.0",
+        "lodash": "^4.17.15",
+        "marked": "^0.6.3",
+        "memoize-one": "^5.1.1",
+        "prop-types": "^15.7.2",
+        "react-bootstrap": "^0.32.1",
+        "react-container-dimensions": "^1.3.3",
+        "react-draggable": "^3.3.2",
+        "react-remarkable": "^1.1.3",
+        "react-tooltip": "^3.11.6"
+      }
     },
     "terser": {
       "version": "4.8.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,8 +20,7 @@
         "react-container-dimensions": "^1.3.3",
         "react-draggable": "^3.3.2",
         "react-remarkable": "^1.1.3",
-        "react-tooltip": "^3.11.6",
-        "tc-ui-toolkit": "github:unfoldingWord/tc-ui-toolkit#feature-mcleanb-raw-usfm"
+        "react-tooltip": "^3.11.6"
       },
       "devDependencies": {
         "@babel/cli": "^7.8.4",
@@ -9267,7 +9266,6 @@
       "version": "16.8.6",
       "resolved": "https://registry.npmjs.org/react/-/react-16.8.6.tgz",
       "integrity": "sha512-pC0uMkhLaHm11ZSJULfOBqV4tIZkx87ZLvbbQYunNixAAvjnC+snJCg0XQXn9VIsttVsbZP/H/ewzgsd5fxKXw==",
-      "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -9342,7 +9340,6 @@
       "version": "16.8.6",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.8.6.tgz",
       "integrity": "sha512-1nL7PIq9LTL3fthPqwkvr2zY7phIPjYrT0jp4HjyEQrEROnw4dG41VVwi/wfoCneoleqrNX7iAD+pXebJZwrwA==",
-      "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -10018,7 +10015,6 @@
       "version": "0.13.6",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.13.6.tgz",
       "integrity": "sha512-IWnObHt413ucAYKsD9J1QShUKkbKLQQHdxRyw73sw4FN26iWr3DY/H34xGPe4nmL1DwXyWmSWmMrA9TfQbE/XQ==",
-      "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -10789,36 +10785,6 @@
       "dev": true,
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/tc-ui-toolkit": {
-      "version": "6.0.1-alpha.3",
-      "resolved": "git+ssh://git@github.com/unfoldingWord/tc-ui-toolkit.git#2304fc5aa4684a3c5c84e77af2035683ee218c34",
-      "license": "MIT",
-      "dependencies": {
-        "@material-ui/core": "^4.10.2",
-        "@material-ui/icons": "^3.0.2",
-        "deep-equal": "^1.1.1",
-        "jest-environment-jsdom": "^24.9.0",
-        "lodash": "^4.17.15",
-        "marked": "^0.6.3",
-        "memoize-one": "^5.1.1",
-        "prop-types": "^15.7.2",
-        "react-bootstrap": "^0.32.1",
-        "react-container-dimensions": "^1.3.3",
-        "react-draggable": "^3.3.2",
-        "react-remarkable": "^1.1.3",
-        "react-tooltip": "^3.11.6"
-      },
-      "engines": {
-        "node": ">=6.11.0"
-      },
-      "peerDependencies": {
-        "react": "^16.3.0",
-        "react-dom": "^16.3.0",
-        "string-punctuation-tokenizer": "^2.0.0",
-        "usfm-js": "^2.1.0",
-        "word-aligner": "^1.0.0"
       }
     },
     "node_modules/terser": {
@@ -13403,7 +13369,8 @@
     "@material-ui/types": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/@material-ui/types/-/types-5.1.0.tgz",
-      "integrity": "sha512-7cqRjrY50b8QzRSYyhSpx4WRw2YuO0KKIGQEVk5J8uoz2BanawykgZGoWEqKm7pVIbzFDN0SpPcVV4IhOFkl8A=="
+      "integrity": "sha512-7cqRjrY50b8QzRSYyhSpx4WRw2YuO0KKIGQEVk5J8uoz2BanawykgZGoWEqKm7pVIbzFDN0SpPcVV4IhOFkl8A==",
+      "requires": {}
     },
     "@material-ui/utils": {
       "version": "4.10.2",
@@ -13800,7 +13767,8 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.2.0.tgz",
       "integrity": "sha512-HiUX/+K2YpkpJ+SzBffkM/AQ2YE03S0U1kjTLVpoJdhZMOWy8qvXVN9JdLqv2QsaQ6MPYQIuNmwD8zOiYUofLQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "acorn-walk": {
       "version": "6.2.0",
@@ -13840,13 +13808,15 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz",
       "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "ajv-keywords": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.0.tgz",
       "integrity": "sha512-eyoaac3btgU8eJlvh01En8OCKzRqlLe2G5jDsCr3RiE2uLGMEEB1aaGwVVpwR8M95956tGH6R+9edC++OvzaVw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "ansi-escapes": {
       "version": "4.3.1",
@@ -14083,7 +14053,8 @@
       "version": "7.0.0-bridge.0",
       "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-7.0.0-bridge.0.tgz",
       "integrity": "sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "babel-eslint": {
       "version": "10.1.0",
@@ -15992,7 +15963,8 @@
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-2.5.1.tgz",
       "integrity": "sha512-Y2c4b55R+6ZzwtTppKwSmK/Kar8AdLiC2f9NADCuxbcTgPPg41Gyqa6b9GppgXSvCtkRw43ZE86CT5sejKC6/g==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-scope": {
       "version": "5.1.0",
@@ -17692,7 +17664,8 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.1.tgz",
       "integrity": "sha512-pgFw2tm54fzgYvc/OHrnysABEObZCUNFnhjoRjaVOCN8NYc032/gVjPaHD4Aq6ApkSieWtfKAFQtmDKAmhupnQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "jest-regex-util": {
       "version": "24.9.0",
@@ -19543,7 +19516,6 @@
       "version": "16.8.6",
       "resolved": "https://registry.npmjs.org/react/-/react-16.8.6.tgz",
       "integrity": "sha512-pC0uMkhLaHm11ZSJULfOBqV4tIZkx87ZLvbbQYunNixAAvjnC+snJCg0XQXn9VIsttVsbZP/H/ewzgsd5fxKXw==",
-      "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -19605,7 +19577,6 @@
       "version": "16.8.6",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.8.6.tgz",
       "integrity": "sha512-1nL7PIq9LTL3fthPqwkvr2zY7phIPjYrT0jp4HjyEQrEROnw4dG41VVwi/wfoCneoleqrNX7iAD+pXebJZwrwA==",
-      "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -20144,7 +20115,6 @@
       "version": "0.13.6",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.13.6.tgz",
       "integrity": "sha512-IWnObHt413ucAYKsD9J1QShUKkbKLQQHdxRyw73sw4FN26iWr3DY/H34xGPe4nmL1DwXyWmSWmMrA9TfQbE/XQ==",
-      "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -20767,25 +20737,6 @@
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.3.tgz",
       "integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==",
       "dev": true
-    },
-    "tc-ui-toolkit": {
-      "version": "git+ssh://git@github.com/unfoldingWord/tc-ui-toolkit.git#2304fc5aa4684a3c5c84e77af2035683ee218c34",
-      "from": "tc-ui-toolkit@unfoldingWord/tc-ui-toolkit#feature-mcleanb-raw-usfm",
-      "requires": {
-        "@material-ui/core": "^4.10.2",
-        "@material-ui/icons": "^3.0.2",
-        "deep-equal": "^1.1.1",
-        "jest-environment-jsdom": "^24.9.0",
-        "lodash": "^4.17.15",
-        "marked": "^0.6.3",
-        "memoize-one": "^5.1.1",
-        "prop-types": "^15.7.2",
-        "react-bootstrap": "^0.32.1",
-        "react-container-dimensions": "^1.3.3",
-        "react-draggable": "^3.3.2",
-        "react-remarkable": "^1.1.3",
-        "react-tooltip": "^3.11.6"
-      }
     },
     "terser": {
       "version": "4.8.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "tc-ui-toolkit",
-  "version": "6.0.0-alpha",
+  "version": "6.0.1-alpha",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "6.0.0-alpha",
+      "version": "6.0.1-alpha",
       "license": "MIT",
       "dependencies": {
         "@material-ui/core": "^4.10.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tc-ui-toolkit",
-  "version": "6.0.1-alpha.2",
+  "version": "6.0.1-alpha.3",
   "description": "React components used to develop tools for the desktop app translationCore",
   "main": "lib/index.js",
   "display": "library",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tc-ui-toolkit",
-  "version": "6.0.0",
+  "version": "6.0.1-alpha",
   "description": "React components used to develop tools for the desktop app translationCore",
   "main": "lib/index.js",
   "display": "library",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tc-ui-toolkit",
-  "version": "6.0.1-alpha",
+  "version": "6.0.1-alpha.2",
   "description": "React components used to develop tools for the desktop app translationCore",
   "main": "lib/index.js",
   "display": "library",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tc-ui-toolkit",
-  "version": "6.0.1-alpha.3",
+  "version": "6.0.1-alpha.4",
   "description": "React components used to develop tools for the desktop app translationCore",
   "main": "lib/index.js",
   "display": "library",
@@ -65,8 +65,8 @@
     "react": "^16.3.0",
     "react-dom": "^16.3.0",
     "string-punctuation-tokenizer": "^2.0.0",
-    "word-aligner": "^1.0.0",
-    "usfm-js": "^2.1.0"
+    "usfm-js": "^2.1.0",
+    "word-aligner": "^1.0.0"
   },
   "dependencies": {
     "@material-ui/core": "^4.10.2",
@@ -81,7 +81,8 @@
     "react-container-dimensions": "^1.3.3",
     "react-draggable": "^3.3.2",
     "react-remarkable": "^1.1.3",
-    "react-tooltip": "^3.11.6"
+    "react-tooltip": "^3.11.6",
+    "tc-ui-toolkit": "github:unfoldingWord/tc-ui-toolkit#feature-mcleanb-raw-usfm"
   },
   "devDependencies": {
     "@babel/cli": "^7.8.4",
@@ -121,9 +122,9 @@
     "react-test-renderer": "16.8.5",
     "string-punctuation-tokenizer": "2.0.0",
     "style-loader": "1.1.3",
+    "usfm-js": "2.1.0",
     "webpack": "^4.42.0",
     "webpack-cli": "^3.3.11",
-    "word-aligner": "1.0.0",
-    "usfm-js": "2.1.0"
+    "word-aligner": "1.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tc-ui-toolkit",
-  "version": "6.0.1-alpha.4",
+  "version": "6.0.1",
   "description": "React components used to develop tools for the desktop app translationCore",
   "main": "lib/index.js",
   "display": "library",
@@ -81,8 +81,7 @@
     "react-container-dimensions": "^1.3.3",
     "react-draggable": "^3.3.2",
     "react-remarkable": "^1.1.3",
-    "react-tooltip": "^3.11.6",
-    "tc-ui-toolkit": "github:unfoldingWord/tc-ui-toolkit#feature-mcleanb-raw-usfm"
+    "react-tooltip": "^3.11.6"
   },
   "devDependencies": {
     "@babel/cli": "^7.8.4",

--- a/src/ScripturePane/ExpandedScripturePaneModal/ChapterView/VerseRow/index.js
+++ b/src/ScripturePane/ExpandedScripturePaneModal/ChapterView/VerseRow/index.js
@@ -40,6 +40,7 @@ class VerseRow extends Component {
       currentVerseNumber,
       currentPaneSettings,
       evenVerse,
+      showTargetUsfm,
     } = this.props;
     let verseCells = [];
 
@@ -80,16 +81,18 @@ class VerseRow extends Component {
           };
           const isTargetBible = bibleId === 'targetBible';
           let fontClass = '';
+          let showUsfm = false;
 
           if (isTargetBible) {
             font = targetLanguageFont;
             fontClass = getFontClassName (targetLanguageFont);
+            showUsfm = showTargetUsfm;
           } else if (font) {
             fontClass = getFontClassName(font);
           }
 
           if (typeof verseData === 'string') { // if the verse content is string.
-            verseElements = verseString(verseData, selections, translate, null, isTargetBible, fontClass);
+            verseElements = verseString(verseData, selections, translate, null, isTargetBible, fontClass, showUsfm);
           } else if (verseData) { // else the verse content is an array of verse objects.
             verseElements = verseArray(verseData, bibleId, contextId, getLexiconData, showPopover, translate, {}, fontClass);
           }
@@ -155,6 +158,7 @@ VerseRow.propTypes = {
   showPopover: PropTypes.func.isRequired,
   targetLanguageFont: PropTypes.string,
   evenVerse: PropTypes.bool,
+  showTargetUsfm: PropTypes.bool,
 };
 
 export default VerseRow;

--- a/src/ScripturePane/ExpandedScripturePaneModal/ChapterView/index.js
+++ b/src/ScripturePane/ExpandedScripturePaneModal/ChapterView/index.js
@@ -65,14 +65,12 @@ class ChapterView extends Component {
     let verseRows = [];
 
     if (verseNumbers.length > 0) {
-      if (showTargetUsfm) {
-        let frontIdx = verseNumbers.indexOf('front');
+      const frontIdx = verseNumbers.indexOf('front');
 
-        if (frontIdx >= 0) { // move front to top
-          const front = verseNumbers[frontIdx];
-          verseNumbers.splice(frontIdx);
-          verseNumbers.unshift(front);
-        }
+      if (showTargetUsfm && (frontIdx > 0)) { // move front to top if not there
+        const front = verseNumbers[frontIdx];
+        verseNumbers.splice(frontIdx);
+        verseNumbers.unshift(front);
       }
 
       for (let i = 0, len = verseNumbers.length; i < len; i++) {

--- a/src/ScripturePane/ExpandedScripturePaneModal/ChapterView/index.js
+++ b/src/ScripturePane/ExpandedScripturePaneModal/ChapterView/index.js
@@ -52,6 +52,7 @@ class ChapterView extends Component {
       currentPaneSettings,
       projectDetailsReducer,
       handleEditTargetVerse,
+      showTargetUsfm,
     } = this.props;
 
     const { chapter, verse } = contextId.reference;
@@ -86,6 +87,7 @@ class ChapterView extends Component {
             onEditTargetVerse={handleEditTargetVerse}
             evenVerse={i % 2 === 0}
             ref={node => this.verseRefs[refKey] = node}
+            showTargetUsfm={showTargetUsfm}
           />,
         );
       }
@@ -151,6 +153,7 @@ ChapterView.propTypes = {
   handleEditTargetVerse: PropTypes.func.isRequired,
   handleEditorSubmit: PropTypes.func.isRequired,
   handleEditorCancel: PropTypes.func.isRequired,
+  showTargetUsfm: PropTypes.bool,
 };
 
 export default ChapterView;

--- a/src/ScripturePane/ExpandedScripturePaneModal/ChapterView/index.js
+++ b/src/ScripturePane/ExpandedScripturePaneModal/ChapterView/index.js
@@ -65,12 +65,14 @@ class ChapterView extends Component {
     let verseRows = [];
 
     if (verseNumbers.length > 0) {
-      let frontIdx = verseNumbers.indexOf('front');
+      if (showTargetUsfm) {
+        let frontIdx = verseNumbers.indexOf('front');
 
-      if (frontIdx >= 0) { // move front to top
-        const front = verseNumbers[frontIdx];
-        verseNumbers.splice(frontIdx);
-        verseNumbers.unshift(front);
+        if (frontIdx >= 0) { // move front to top
+          const front = verseNumbers[frontIdx];
+          verseNumbers.splice(frontIdx);
+          verseNumbers.unshift(front);
+        }
       }
 
       for (let i = 0, len = verseNumbers.length; i < len; i++) {

--- a/src/ScripturePane/ExpandedScripturePaneModal/ChapterView/index.js
+++ b/src/ScripturePane/ExpandedScripturePaneModal/ChapterView/index.js
@@ -65,6 +65,14 @@ class ChapterView extends Component {
     let verseRows = [];
 
     if (verseNumbers.length > 0) {
+      let frontIdx = verseNumbers.indexOf('front');
+
+      if (frontIdx >= 0) { // move front to top
+        const front = verseNumbers[frontIdx];
+        verseNumbers.splice(frontIdx);
+        verseNumbers.unshift(front);
+      }
+
       for (let i = 0, len = verseNumbers.length; i < len; i++) {
         const verseNumber = verseNumbers[i];
         const { verseLabel } = getVerseData(bibles, languageID, bookID, chapter, verse);

--- a/src/ScripturePane/ExpandedScripturePaneModal/index.js
+++ b/src/ScripturePane/ExpandedScripturePaneModal/index.js
@@ -44,6 +44,7 @@ const styles = {
     fontSize: '22px',
     fontWeight: '400',
   },
+  usfmButton: { marginLeft: 'auto' },
   closeButton: { marginLeft: 'auto' },
   dialogContent: {
     padding: '0px',
@@ -129,16 +130,16 @@ function ExpandedScripturePaneModal({
           {title}
         </div>
         <IconButton
-          title={showTargetUsfm ? 'Show USFM' : 'Hide USFM'}
-          aria-label={showTargetUsfm ? 'ShowUSFM' : 'HideUSGM'}
+          title={showTargetUsfm ? 'Hide USFM' : 'Show USFM'}
+          aria-label={showTargetUsfm ? 'HideUSGM' : 'ShowUSFM'}
           onClick={() => toggleUsfm()}
-          className={classes.margin}
+          style={styles.usfmButton}
           color="inherit"
         >
           {showTargetUsfm ? (
-            <VisibilityOffIcon id='visibility_icon' htmlColor='#000' />
+            <VisibilityOffIcon id='visibility_icon' htmlColor='#FFF' />
           ) : (
-            <VisibilityIcon id='visibility_icon' htmlColor='#000' />
+            <VisibilityIcon id='visibility_icon' htmlColor='#FFF' />
           )}
         </IconButton>
         <IconButton color="inherit" onClick={onHide} aria-label="Close" style={styles.closeButton}>

--- a/src/ScripturePane/ExpandedScripturePaneModal/index.js
+++ b/src/ScripturePane/ExpandedScripturePaneModal/index.js
@@ -5,6 +5,8 @@ import DialogActions from '@material-ui/core/DialogActions';
 import DialogContent from '@material-ui/core/DialogContent';
 import Toolbar from '@material-ui/core/Toolbar';
 import IconButton from '@material-ui/core/IconButton';
+import VisibilityIcon from '@material-ui/icons/Visibility';
+import VisibilityOffIcon from '@material-ui/icons/VisibilityOff';
 import { Glyphicon } from 'react-bootstrap';
 import { withStyles } from '@material-ui/core/styles';
 // components
@@ -75,6 +77,7 @@ function ExpandedScripturePaneModal({
   projectDetailsReducer,
 }) {
   const [verseTextReference, editVerseText] = useState({});
+  const [showTargetUsfm, setShowTargetUsfm] = useState(false);
 
   function handleEditTargetVerse(bibleId, chapter, verse, verseText) {
     editVerseText(prevState => ({
@@ -84,7 +87,11 @@ function ExpandedScripturePaneModal({
       verse,
       verseText,
     }));
-  };
+  }
+
+  function toggleUsfm() {
+    setShowTargetUsfm(!showTargetUsfm);
+  }
 
   function handleEditorSubmit(originalVerse, newVerse, reasons) {
     if (Object.keys(verseTextReference).length === 0) {
@@ -121,6 +128,19 @@ function ExpandedScripturePaneModal({
         <div style={styles.title} className={fontClass}>
           {title}
         </div>
+        <IconButton
+          title={showTargetUsfm ? 'Show USFM' : 'Hide USFM'}
+          aria-label={showTargetUsfm ? 'ShowUSFM' : 'HideUSGM'}
+          onClick={() => toggleUsfm()}
+          className={classes.margin}
+          color="inherit"
+        >
+          {showTargetUsfm ? (
+            <VisibilityOffIcon id='visibility_icon' htmlColor='#000' />
+          ) : (
+            <VisibilityIcon id='visibility_icon' htmlColor='#000' />
+          )}
+        </IconButton>
         <IconButton color="inherit" onClick={onHide} aria-label="Close" style={styles.closeButton}>
           <Glyphicon glyph="remove" />
         </IconButton>
@@ -144,7 +164,7 @@ function ExpandedScripturePaneModal({
           selections={selections}
           showPopover={showPopover}
           getLexiconData={getLexiconData}
-          showTargetUsfm={true}
+          showTargetUsfm={showTargetUsfm}
         />
       </DialogContent>
       <DialogActions disableSpacing style={styles.dialogActions}>

--- a/src/ScripturePane/ExpandedScripturePaneModal/index.js
+++ b/src/ScripturePane/ExpandedScripturePaneModal/index.js
@@ -45,7 +45,7 @@ const styles = {
     fontWeight: '400',
   },
   usfmButton: { marginLeft: 'auto' },
-  closeButton: { marginLeft: 'auto' },
+  closeButton: { marginLeft: '10px' },
   dialogContent: {
     padding: '0px',
     margin: '0px',
@@ -137,9 +137,9 @@ function ExpandedScripturePaneModal({
           color="inherit"
         >
           {showTargetUsfm ? (
-            <VisibilityOffIcon id='visibility_icon' htmlColor='#FFF' />
-          ) : (
             <VisibilityIcon id='visibility_icon' htmlColor='#FFF' />
+          ) : (
+            <VisibilityOffIcon id='visibility_icon' htmlColor='#FFF' />
           )}
         </IconButton>
         <IconButton color="inherit" onClick={onHide} aria-label="Close" style={styles.closeButton}>

--- a/src/ScripturePane/ExpandedScripturePaneModal/index.js
+++ b/src/ScripturePane/ExpandedScripturePaneModal/index.js
@@ -143,7 +143,9 @@ function ExpandedScripturePaneModal({
           handleEditorCancel={handleEditorCancel}
           selections={selections}
           showPopover={showPopover}
-          getLexiconData={getLexiconData} />
+          getLexiconData={getLexiconData}
+          showTargetUsfm={true}
+        />
       </DialogContent>
       <DialogActions disableSpacing style={styles.dialogActions}>
         <button className="btn-prime" onClick={onHide}>

--- a/src/ScripturePane/helpers/verseHelpers.js
+++ b/src/ScripturePane/helpers/verseHelpers.js
@@ -56,10 +56,14 @@ function textToHtml(text, showUsfm) {
  * @return {*}
  */
 export const verseString = (verseText, selections, translate, fontStyle = null, isTargetBible, fontClass, showUsfm) => {
-  let newVerseText = showUsfm ? verseText : removeMarker(verseText);
-  newVerseText = newVerseText.replace(/\s+/g, ' ');
-  // if string only contains spaces then make it an empty string
-  newVerseText = newVerseText.replace(/\s/g, '').length === 0 ? '' : newVerseText;
+  let newVerseText = verseText;
+
+  if (!showUsfm) {
+    removeMarker(verseText);
+    newVerseText = newVerseText.replace(/\s+/g, ' ');
+    // if string only contains spaces then make it an empty string
+    newVerseText = newVerseText.replace(/\s/g, '').length === 0 ? '' : newVerseText;
+  }
 
   // if empty string then newVerseText = place holder warning.
   if (newVerseText.length === 0) {

--- a/src/ScripturePane/helpers/verseHelpers.js
+++ b/src/ScripturePane/helpers/verseHelpers.js
@@ -32,10 +32,11 @@ import {
  * @param {Object} fontStyle - font specific styling
  * @param {String} isTargetBible
  * @param {String} fontClass
+ * @param {boolean} showUsfm
  * @return {*}
  */
-export const verseString = (verseText, selections, translate, fontStyle = null, isTargetBible, fontClass) => {
-  let newVerseText = removeMarker(verseText);
+export const verseString = (verseText, selections, translate, fontStyle = null, isTargetBible, fontClass, showUsfm) => {
+  let newVerseText = showUsfm ? verseText : removeMarker(verseText);
   newVerseText = newVerseText.replace(/\s+/g, ' ');
   // if string only contains spaces then make it an empty string
   newVerseText = newVerseText.replace(/\s/g, '').length === 0 ? '' : newVerseText;

--- a/src/ScripturePane/helpers/verseHelpers.js
+++ b/src/ScripturePane/helpers/verseHelpers.js
@@ -66,7 +66,7 @@ export const verseString = (verseText, selections, translate, fontStyle = null, 
     newVerseText = translate('pane.missing_verse_warning');
   }
 
-  let verseTextSpans = <span className={fontClass}>{newVerseText}</span>;
+  let verseTextSpans = <span className={fontClass}>{textToHtml(newVerseText, showUsfm)}</span>;
 
   if (selections && selections.length > 0) {
     const _selectionArray = stringTokenizer.selectionArray(newVerseText, selections);
@@ -86,7 +86,7 @@ export const verseString = (verseText, selections, translate, fontStyle = null, 
       }
       verseTextSpans.push(
         <span key={index} className={fontClass} style={spanStyle}>
-          {textToHtml(selection, showUsfm)}
+          {selection.text}
         </span>,
       );
     }

--- a/src/ScripturePane/helpers/verseHelpers.js
+++ b/src/ScripturePane/helpers/verseHelpers.js
@@ -25,6 +25,26 @@ import {
 } from './stringHelpers';
 
 /**
+ * if showing html, replace
+ * @param {object} selection
+ * @param {boolean} showUsfm
+ * @return {JSX.Element}
+ */
+function textToHtml(selection, showUsfm) {
+  if (showUsfm && (selection.text.indexOf('\n') >= 0)) {
+    const parts = selection.text.split('\n');
+    const html = [parts[0]];
+
+    for (let i = 1; i < parts.length; i++) {
+      html.push(<br/>);
+      html.push(parts[i]);
+    }
+    return <> {html} </>;
+  }
+  return <>{selection.text}</>;
+}
+
+/**
  *
  * @param {String} verseText
  * @param {Array} selections - text selections to highlight
@@ -66,7 +86,7 @@ export const verseString = (verseText, selections, translate, fontStyle = null, 
       }
       verseTextSpans.push(
         <span key={index} className={fontClass} style={spanStyle}>
-          {selection.text}
+          {textToHtml(selection, showUsfm)}
         </span>,
       );
     }

--- a/src/ScripturePane/helpers/verseHelpers.js
+++ b/src/ScripturePane/helpers/verseHelpers.js
@@ -25,7 +25,7 @@ import {
 } from './stringHelpers';
 
 /**
- * if showing html, replace
+ * if showing USFM codes, replace newlines
  * @param {string} text
  * @param {boolean} showUsfm
  * @return {JSX.Element}
@@ -36,6 +36,7 @@ function textToHtml(text, showUsfm) {
     const html = [parts[0]];
 
     for (let i = 1; i < parts.length; i++) {
+      html.push('↲');
       html.push(<br/>);
       html.push(parts[i]);
     }
@@ -45,12 +46,12 @@ function textToHtml(text, showUsfm) {
 }
 
 /**
- *
+ * render text as HTML and overlay any selections
  * @param {String} verseText
  * @param {Array} selections - text selections to highlight
  * @param {Function} translate
  * @param {Object} fontStyle - font specific styling
- * @param {String} isTargetBible
+ * @param {boolean} isTargetBible
  * @param {String} fontClass
  * @param {boolean} showUsfm
  * @return {*}

--- a/src/ScripturePane/helpers/verseHelpers.js
+++ b/src/ScripturePane/helpers/verseHelpers.js
@@ -59,7 +59,7 @@ export const verseString = (verseText, selections, translate, fontStyle = null, 
   let newVerseText = verseText;
 
   if (!showUsfm) {
-    removeMarker(verseText);
+    newVerseText = removeMarker(verseText);
     newVerseText = newVerseText.replace(/\s+/g, ' ');
     // if string only contains spaces then make it an empty string
     newVerseText = newVerseText.replace(/\s/g, '').length === 0 ? '' : newVerseText;

--- a/src/ScripturePane/helpers/verseHelpers.js
+++ b/src/ScripturePane/helpers/verseHelpers.js
@@ -26,22 +26,22 @@ import {
 
 /**
  * if showing html, replace
- * @param {object} selection
+ * @param {string} text
  * @param {boolean} showUsfm
  * @return {JSX.Element}
  */
-function textToHtml(selection, showUsfm) {
-  if (showUsfm && (selection.text.indexOf('\n') >= 0)) {
-    const parts = selection.text.split('\n');
+function textToHtml(text, showUsfm) {
+  if (showUsfm && (text.indexOf('\n') >= 0)) {
+    const parts = text.split('\n');
     const html = [parts[0]];
 
     for (let i = 1; i < parts.length; i++) {
       html.push(<br/>);
       html.push(parts[i]);
     }
-    return <> {html} </>;
+    return html;
   }
-  return <>{selection.text}</>;
+  return text;
 }
 
 /**


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- added button to expanded scripture pane to toggle raw USFM view.


#### Please include detailed Test instructions for your pull request:

- [x] test with build here: https://github.com/unfoldingWord/translationCore/actions/runs/1789872696
- [x] download from D43: `https://git.door43.org/photonomad0/en_ustz_gal_book`
- [x] open WA tool to chapter 1 and expand scripture pane.  It should look like:

![Screen Shot 2022-02-03 at 11 26 41 AM](https://user-images.githubusercontent.com/14238574/152385508-edea4cda-c5f5-4db6-8317-e9396d3f059c.png)

- [x] click on the eye icon and it should change to show:

![Screen Shot 2022-02-03 at 11 27 00 AM](https://user-images.githubusercontent.com/14238574/152385597-1e38b691-9514-4707-9efb-5820049dcddc.png)

- [x] verify works in tW
- [x] verify works in tN


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword/tc-ui-toolkit/328)
<!-- Reviewable:end -->
