### PR TITLE
Bugfix 7226/Highlighting messes up USFM preview. 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "tc-ui-toolkit",
-  "version": "6.0.1-alpha.4",
+  "version": "6.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "6.0.1-alpha.4",
+      "version": "6.0.1",
       "license": "MIT",
       "dependencies": {
         "@material-ui/core": "^4.10.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "tc-ui-toolkit",
-  "version": "6.0.1",
+  "version": "6.0.2-alpha",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "6.0.1",
+      "version": "6.0.2-alpha",
       "license": "MIT",
       "dependencies": {
         "@material-ui/core": "^4.10.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tc-ui-toolkit",
-  "version": "6.0.1",
+  "version": "6.0.2",
   "description": "React components used to develop tools for the desktop app translationCore",
   "main": "lib/index.js",
   "display": "library",

--- a/src/ScripturePane/helpers/verseHelpers.js
+++ b/src/ScripturePane/helpers/verseHelpers.js
@@ -73,7 +73,7 @@ export const verseString = (verseText, selections, translate, fontStyle = null, 
 
   let verseTextSpans = <span className={fontClass}>{textToHtml(newVerseText, showUsfm)}</span>;
 
-  if (selections && selections.length > 0) {
+  if (!showUsfm && selections && selections.length > 0) {
     const _selectionArray = stringTokenizer.selectionArray(newVerseText, selections);
     verseTextSpans = [];
     verseTextSpans.length = 0;


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- turn off highlighting when in USFM preview

#### Please include detailed Test instructions for your pull request:

- [x] test with: https://github.com/unfoldingWord/translationCore/actions/runs/1815122313
- [x] use project:  [en_ust_gal_book.zip](https://github.com/unfoldingWord/tc-ui-toolkit/files/8028254/en_ust_gal_book.zip)
- [x] make sure that newlines are shown in tWords when selection has been made for Paul in 1:1-2:


<img width="1201" alt="Screen Shot 2022-02-08 at 6 38 49 PM" src="https://user-images.githubusercontent.com/14238574/153094351-4fe8ede4-5a0d-4905-a143-d9d39290e180.png">



<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword/tc-ui-toolkit/329)
<!-- Reviewable:end -->
